### PR TITLE
Backport of CVE 2024 22019 for v14.x

### DIFF
--- a/deps/llhttp/.gitignore
+++ b/deps/llhttp/.gitignore
@@ -1,0 +1,1 @@
+libllhttp.pc

--- a/deps/llhttp/CMakeLists.txt
+++ b/deps/llhttp/CMakeLists.txt
@@ -1,0 +1,115 @@
+cmake_minimum_required(VERSION 3.5.1)
+cmake_policy(SET CMP0069 NEW)
+
+project(llhttp VERSION 6.1.0)
+include(GNUInstallDirs)
+
+set(CMAKE_C_STANDARD 99)
+
+# By default build in relwithdebinfo type, supports both lowercase and uppercase
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  set(allowableBuildTypes DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${allowableBuildTypes}")
+  if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RELWITHDEBINFO CACHE STRING "" FORCE)
+  else()
+    string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
+    if(NOT CMAKE_BUILD_TYPE IN_LIST allowableBuildTypes)
+      message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}")
+    endif()
+  endif()
+endif()
+
+#
+# Options
+#
+# Generic option
+option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so)" ON)
+option(BUILD_STATIC_LIBS "Build static libraries (.lib/.a)" OFF)
+
+# Source code
+set(LLHTTP_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/llhttp.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/http.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/api.c
+)
+
+set(LLHTTP_HEADERS
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/llhttp.h
+)
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libllhttp.pc.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/libllhttp.pc
+  @ONLY
+)
+
+function(config_library target)
+  target_sources(${target} PRIVATE ${LLHTTP_SOURCES} ${LLHTTP_HEADERS})
+
+  target_include_directories(${target} PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+
+  set_target_properties(${target} PROPERTIES
+    OUTPUT_NAME llhttp
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    PUBLIC_HEADER ${LLHTTP_HEADERS}
+  )
+
+  install(TARGETS ${target}
+    EXPORT llhttp
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
+  install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/libllhttp.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+  )
+
+  # This is required to work with FetchContent
+  install(EXPORT llhttp
+        FILE llhttp-config.cmake
+        NAMESPACE llhttp::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/llhttp)
+endfunction(config_library target)
+
+if(BUILD_SHARED_LIBS)
+  add_library(llhttp_shared SHARED
+      ${llhttp_src}
+  )
+  add_library(llhttp::llhttp ALIAS llhttp_shared)
+  config_library(llhttp_shared)
+endif()
+
+if(BUILD_STATIC_LIBS)
+  add_library(llhttp_static STATIC
+      ${llhttp_src}
+  )
+  if(BUILD_SHARED_LIBS)
+    add_library(llhttp::llhttp ALIAS llhttp_shared)
+  else()
+    add_library(llhttp::llhttp ALIAS llhttp_static)
+  endif()
+  config_library(llhttp_static)
+endif()
+
+# On windows with Visual Studio, add a debug postfix so that release
+# and debug libraries can coexist.
+if(MSVC)
+  set(CMAKE_DEBUG_POSTFIX "d")
+endif()
+
+# Print project configure summary
+message(STATUS "")
+message(STATUS "")
+message(STATUS "Project configure summary:")
+message(STATUS "")
+message(STATUS "  CMake build type .................: ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Install prefix ...................: ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "  Build shared library .............: ${BUILD_SHARED_LIBS}")
+message(STATUS "  Build static library .............: ${BUILD_STATIC_LIBS}")
+message(STATUS "")

--- a/deps/llhttp/README.md
+++ b/deps/llhttp/README.md
@@ -1,4 +1,5 @@
 # llhttp
+[![CI](https://github.com/nodejs/llhttp/workflows/CI/badge.svg)](https://github.com/nodejs/llhttp/actions?query=workflow%3ACI)
 
 Port of [http_parser][0] to [llparse][1].
 
@@ -22,7 +23,7 @@ were tried. However, all of them failed due to resulting significant performance
 degradation.
 
 This project is a port of [http_parser][0] to TypeScript. [llparse][1] is used
-to generate the output C and/or bitcode artifacts, which could be compiled and
+to generate the output C source file, which could be compiled and
 linked with the embedder's program (like [Node.js][7]).
 
 ## Performance
@@ -31,7 +32,7 @@ So far llhttp outperforms http_parser:
 
 |                 | input size |  bandwidth   |  reqs/sec  |   time  |
 |:----------------|-----------:|-------------:|-----------:|--------:|
-| **llhttp** _(C)_ | 8192.00 mb | 1777.24 mb/s | 3583799.39 ops/sec | 4.61 s |
+| **llhttp**      | 8192.00 mb | 1777.24 mb/s | 3583799.39 req/sec | 4.61 s |
 | **http_parser** | 8192.00 mb | 694.66 mb/s | 1406180.33 req/sec | 11.79 s |
 
 llhttp is faster by approximately **156%**.
@@ -89,8 +90,59 @@ if (err == HPE_OK) {
           parser.reason);
 }
 ```
+For more information on API usage, please refer to [src/native/api.h](https://github.com/nodejs/llhttp/blob/main/src/native/api.h).
+
+## Build Instructions
+
+Make sure you have [Node.js](https://nodejs.org/), npm and npx installed. Then under project directory run:
+
+```sh
+npm install
+make
+```
 
 ---
+
+### Bindings to other languages
+
+* Python: [pallas/pyllhttp][8]
+* Ruby: [metabahn/llhttp][9]
+* Rust: [JackLiar/rust-llhttp][10]
+
+### Using with CMake
+
+If you want to use this library in a CMake project you can use the snippet below.
+
+```
+FetchContent_Declare(llhttp
+  URL "https://github.com/nodejs/llhttp/archive/refs/tags/v6.0.5.tar.gz")  # Using version 6.0.5
+
+FetchContent_MakeAvailable(llhttp)
+
+target_link_libraries(${EXAMPLE_PROJECT_NAME} ${PROJECT_LIBRARIES} llhttp ${PROJECT_NAME})
+```
+
+## Building on Windows
+
+### Installation
+
+* `choco install git`
+* `choco install node`
+* `choco install llvm` (or install the `C++ Clang tools for Windows` optional package from the Visual Studio 2019 installer)
+* `choco install make` (or if you have MinGW, it comes bundled)
+
+1. Ensure that `Clang` and `make` are in your system path.
+2. Using Git Bash, clone the repo to your preferred location.
+3. Cd into the cloned directory and run `npm install`
+5. Run `make`
+6. Your `repo/build` directory should now have `libllhttp.a` and `libllhttp.so` static and dynamic libraries.
+7. When building your executable, you can link to these libraries. Make sure to set the build folder as an include path when building so you can reference the declarations in `repo/build/llhttp.h`.
+
+### A simple example on linking with the library:
+
+Assuming you have an executable `main.cpp` in your current working directory, you would run: `clang++ -Os -g3 -Wall -Wextra -Wno-unused-parameter -I/path/to/llhttp/build main.cpp /path/to/llhttp/build/libllhttp.a -o main.exe`.
+
+If you are getting `unresolved external symbol` linker errors you are likely attempting to build `llhttp.c` without linking it with object files from `api.c` and `http.c`.
 
 #### LICENSE
 
@@ -125,3 +177,6 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 [5]: https://llvm.org/docs/LangRef.html#call-instruction
 [6]: https://clang.llvm.org/
 [7]: https://github.com/nodejs/node
+[8]: https://github.com/pallas/pyllhttp
+[9]: https://github.com/metabahn/llhttp
+[10]: https://github.com/JackLiar/rust-llhttp

--- a/deps/llhttp/include/llhttp.h
+++ b/deps/llhttp/include/llhttp.h
@@ -1,9 +1,9 @@
 #ifndef INCLUDE_LLHTTP_H_
 #define INCLUDE_LLHTTP_H_
 
-#define LLHTTP_VERSION_MAJOR 2
+#define LLHTTP_VERSION_MAJOR 6
 #define LLHTTP_VERSION_MINOR 1
-#define LLHTTP_VERSION_PATCH 6
+#define LLHTTP_VERSION_PATCH 0
 
 #ifndef LLHTTP_STRICT_MODE
 # define LLHTTP_STRICT_MODE 0
@@ -33,10 +33,11 @@ struct llhttp__internal_s {
   uint8_t http_major;
   uint8_t http_minor;
   uint8_t header_state;
-  uint16_t flags;
+  uint8_t lenient_flags;
   uint8_t upgrade;
-  uint16_t status_code;
   uint8_t finish;
+  uint16_t flags;
+  uint16_t status_code;
   void* settings;
 };
 
@@ -79,6 +80,7 @@ enum llhttp_errno {
   HPE_CB_CHUNK_COMPLETE = 20,
   HPE_PAUSED = 21,
   HPE_PAUSED_UPGRADE = 22,
+  HPE_PAUSED_H2_UPGRADE = 23,
   HPE_USER = 24
 };
 typedef enum llhttp_errno llhttp_errno_t;
@@ -92,10 +94,18 @@ enum llhttp_flags {
   F_CONTENT_LENGTH = 0x20,
   F_SKIPBODY = 0x40,
   F_TRAILING = 0x80,
-  F_LENIENT = 0x100,
   F_TRANSFER_ENCODING = 0x200
 };
 typedef enum llhttp_flags llhttp_flags_t;
+
+enum llhttp_lenient_flags {
+  LENIENT_HEADERS = 0x1,
+  LENIENT_CHUNKED_LENGTH = 0x2,
+  LENIENT_KEEP_ALIVE = 0x4,
+  LENIENT_TRANSFER_ENCODING = 0x8,
+  LENIENT_VERSION = 0x10
+};
+typedef enum llhttp_lenient_flags llhttp_lenient_flags_t;
 
 enum llhttp_type {
   HTTP_BOTH = 0,
@@ -146,7 +156,18 @@ enum llhttp_method {
   HTTP_LINK = 31,
   HTTP_UNLINK = 32,
   HTTP_SOURCE = 33,
-  HTTP_PRI = 34
+  HTTP_PRI = 34,
+  HTTP_DESCRIBE = 35,
+  HTTP_ANNOUNCE = 36,
+  HTTP_SETUP = 37,
+  HTTP_PLAY = 38,
+  HTTP_PAUSE = 39,
+  HTTP_TEARDOWN = 40,
+  HTTP_GET_PARAMETER = 41,
+  HTTP_SET_PARAMETER = 42,
+  HTTP_REDIRECT = 43,
+  HTTP_RECORD = 44,
+  HTTP_FLUSH = 45
 };
 typedef enum llhttp_method llhttp_method_t;
 
@@ -175,6 +196,7 @@ typedef enum llhttp_method llhttp_method_t;
   XX(20, CB_CHUNK_COMPLETE, CB_CHUNK_COMPLETE) \
   XX(21, PAUSED, PAUSED) \
   XX(22, PAUSED_UPGRADE, PAUSED_UPGRADE) \
+  XX(23, PAUSED_H2_UPGRADE, PAUSED_H2_UPGRADE) \
   XX(24, USER, USER) \
 
 
@@ -213,8 +235,72 @@ typedef enum llhttp_method llhttp_method_t;
   XX(31, LINK, LINK) \
   XX(32, UNLINK, UNLINK) \
   XX(33, SOURCE, SOURCE) \
-  XX(34, PRI, PRI) \
 
+
+#define RTSP_METHOD_MAP(XX) \
+  XX(1, GET, GET) \
+  XX(3, POST, POST) \
+  XX(6, OPTIONS, OPTIONS) \
+  XX(35, DESCRIBE, DESCRIBE) \
+  XX(36, ANNOUNCE, ANNOUNCE) \
+  XX(37, SETUP, SETUP) \
+  XX(38, PLAY, PLAY) \
+  XX(39, PAUSE, PAUSE) \
+  XX(40, TEARDOWN, TEARDOWN) \
+  XX(41, GET_PARAMETER, GET_PARAMETER) \
+  XX(42, SET_PARAMETER, SET_PARAMETER) \
+  XX(43, REDIRECT, REDIRECT) \
+  XX(44, RECORD, RECORD) \
+  XX(45, FLUSH, FLUSH) \
+
+
+#define HTTP_ALL_METHOD_MAP(XX) \
+  XX(0, DELETE, DELETE) \
+  XX(1, GET, GET) \
+  XX(2, HEAD, HEAD) \
+  XX(3, POST, POST) \
+  XX(4, PUT, PUT) \
+  XX(5, CONNECT, CONNECT) \
+  XX(6, OPTIONS, OPTIONS) \
+  XX(7, TRACE, TRACE) \
+  XX(8, COPY, COPY) \
+  XX(9, LOCK, LOCK) \
+  XX(10, MKCOL, MKCOL) \
+  XX(11, MOVE, MOVE) \
+  XX(12, PROPFIND, PROPFIND) \
+  XX(13, PROPPATCH, PROPPATCH) \
+  XX(14, SEARCH, SEARCH) \
+  XX(15, UNLOCK, UNLOCK) \
+  XX(16, BIND, BIND) \
+  XX(17, REBIND, REBIND) \
+  XX(18, UNBIND, UNBIND) \
+  XX(19, ACL, ACL) \
+  XX(20, REPORT, REPORT) \
+  XX(21, MKACTIVITY, MKACTIVITY) \
+  XX(22, CHECKOUT, CHECKOUT) \
+  XX(23, MERGE, MERGE) \
+  XX(24, MSEARCH, M-SEARCH) \
+  XX(25, NOTIFY, NOTIFY) \
+  XX(26, SUBSCRIBE, SUBSCRIBE) \
+  XX(27, UNSUBSCRIBE, UNSUBSCRIBE) \
+  XX(28, PATCH, PATCH) \
+  XX(29, PURGE, PURGE) \
+  XX(30, MKCALENDAR, MKCALENDAR) \
+  XX(31, LINK, LINK) \
+  XX(32, UNLINK, UNLINK) \
+  XX(33, SOURCE, SOURCE) \
+  XX(34, PRI, PRI) \
+  XX(35, DESCRIBE, DESCRIBE) \
+  XX(36, ANNOUNCE, ANNOUNCE) \
+  XX(37, SETUP, SETUP) \
+  XX(38, PLAY, PLAY) \
+  XX(39, PAUSE, PAUSE) \
+  XX(40, TEARDOWN, TEARDOWN) \
+  XX(41, GET_PARAMETER, GET_PARAMETER) \
+  XX(42, SET_PARAMETER, SET_PARAMETER) \
+  XX(43, REDIRECT, REDIRECT) \
+  XX(44, RECORD, RECORD) \
+  XX(45, FLUSH, FLUSH) \
 
 
 #ifdef __cplusplus
@@ -229,6 +315,12 @@ extern "C" {
 #endif
 #include <stddef.h>
 
+#if defined(__wasm__)
+#define LLHTTP_EXPORT __attribute__((visibility("default")))
+#else
+#define LLHTTP_EXPORT
+#endif
+
 typedef llhttp__internal_t llhttp_t;
 typedef struct llhttp_settings_s llhttp_settings_t;
 
@@ -239,6 +331,7 @@ struct llhttp_settings_s {
   /* Possible return values 0, -1, `HPE_PAUSED` */
   llhttp_cb      on_message_begin;
 
+  /* Possible return values 0, -1, HPE_USER */
   llhttp_data_cb on_url;
   llhttp_data_cb on_status;
   llhttp_data_cb on_header_field;
@@ -255,6 +348,10 @@ struct llhttp_settings_s {
    */
   llhttp_cb      on_headers_complete;
 
+  /* Possible return values 0, -1, HPE_USER */
+  llhttp_data_cb on_chunk_parameters;
+
+  /* Possible return values 0, -1, HPE_USER */
   llhttp_data_cb on_body;
 
   /* Possible return values 0, -1, `HPE_PAUSED` */
@@ -266,13 +363,56 @@ struct llhttp_settings_s {
    */
   llhttp_cb      on_chunk_header;
   llhttp_cb      on_chunk_complete;
+
+  /* Information-only callbacks, return value is ignored */
+  llhttp_cb      on_url_complete;
+  llhttp_cb      on_status_complete;
+  llhttp_cb      on_header_field_complete;
+  llhttp_cb      on_header_value_complete;
 };
 
-/* Initialize the parser with specific type and user settings */
+/* Initialize the parser with specific type and user settings.
+ *
+ * NOTE: lifetime of `settings` has to be at least the same as the lifetime of
+ * the `parser` here. In practice, `settings` has to be either a static
+ * variable or be allocated with `malloc`, `new`, etc.
+ */
+LLHTTP_EXPORT
 void llhttp_init(llhttp_t* parser, llhttp_type_t type,
                  const llhttp_settings_t* settings);
 
+LLHTTP_EXPORT
+llhttp_t* llhttp_alloc(llhttp_type_t type);
+
+LLHTTP_EXPORT
+void llhttp_free(llhttp_t* parser);
+
+LLHTTP_EXPORT
+uint8_t llhttp_get_type(llhttp_t* parser);
+
+LLHTTP_EXPORT
+uint8_t llhttp_get_http_major(llhttp_t* parser);
+
+LLHTTP_EXPORT
+uint8_t llhttp_get_http_minor(llhttp_t* parser);
+
+LLHTTP_EXPORT
+uint8_t llhttp_get_method(llhttp_t* parser);
+
+LLHTTP_EXPORT
+int llhttp_get_status_code(llhttp_t* parser);
+
+LLHTTP_EXPORT
+uint8_t llhttp_get_upgrade(llhttp_t* parser);
+
+/* Reset an already initialized parser back to the start state, preserving the
+ * existing parser type, callback settings, user data, and lenient flags.
+ */
+LLHTTP_EXPORT
+void llhttp_reset(llhttp_t* parser);
+
 /* Initialize the settings object */
+LLHTTP_EXPORT
 void llhttp_settings_init(llhttp_settings_t* settings);
 
 /* Parse full or partial request/response, invoking user callbacks along the
@@ -291,6 +431,7 @@ void llhttp_settings_init(llhttp_settings_t* settings);
  * to return the same error upon each successive call up until `llhttp_init()`
  * is called.
  */
+LLHTTP_EXPORT
 llhttp_errno_t llhttp_execute(llhttp_t* parser, const char* data, size_t len);
 
 /* This method should be called when the other side has no further bytes to
@@ -301,16 +442,19 @@ llhttp_errno_t llhttp_execute(llhttp_t* parser, const char* data, size_t len);
  * connection. This method will invoke `on_message_complete()` callback if the
  * request was terminated safely. Otherwise a error code would be returned.
  */
+LLHTTP_EXPORT
 llhttp_errno_t llhttp_finish(llhttp_t* parser);
 
 /* Returns `1` if the incoming message is parsed until the last byte, and has
  * to be completed by calling `llhttp_finish()` on EOF
  */
+LLHTTP_EXPORT
 int llhttp_message_needs_eof(const llhttp_t* parser);
 
 /* Returns `1` if there might be any other messages following the last that was
  * successfully parsed.
  */
+LLHTTP_EXPORT
 int llhttp_should_keep_alive(const llhttp_t* parser);
 
 /* Make further calls of `llhttp_execute()` return `HPE_PAUSED` and set
@@ -319,6 +463,7 @@ int llhttp_should_keep_alive(const llhttp_t* parser);
  * Important: do not call this from user callbacks! User callbacks must return
  * `HPE_PAUSED` if pausing is required.
  */
+LLHTTP_EXPORT
 void llhttp_pause(llhttp_t* parser);
 
 /* Might be called to resume the execution after the pause in user's callback.
@@ -326,6 +471,7 @@ void llhttp_pause(llhttp_t* parser);
  *
  * Call this only if `llhttp_execute()` returns `HPE_PAUSED`.
  */
+LLHTTP_EXPORT
 void llhttp_resume(llhttp_t* parser);
 
 /* Might be called to resume the execution after the pause in user's callback.
@@ -333,9 +479,11 @@ void llhttp_resume(llhttp_t* parser);
  *
  * Call this only if `llhttp_execute()` returns `HPE_PAUSED_UPGRADE`
  */
+LLHTTP_EXPORT
 void llhttp_resume_after_upgrade(llhttp_t* parser);
 
 /* Returns the latest return error */
+LLHTTP_EXPORT
 llhttp_errno_t llhttp_get_errno(const llhttp_t* parser);
 
 /* Returns the verbal explanation of the latest returned error.
@@ -343,6 +491,7 @@ llhttp_errno_t llhttp_get_errno(const llhttp_t* parser);
  * Note: User callback should set error reason when returning the error. See
  * `llhttp_set_error_reason()` for details.
  */
+LLHTTP_EXPORT
 const char* llhttp_get_error_reason(const llhttp_t* parser);
 
 /* Assign verbal description to the returned error. Must be called in user
@@ -350,6 +499,7 @@ const char* llhttp_get_error_reason(const llhttp_t* parser);
  *
  * Note: `HPE_USER` error code might be useful in user callbacks.
  */
+LLHTTP_EXPORT
 void llhttp_set_error_reason(llhttp_t* parser, const char* reason);
 
 /* Returns the pointer to the last parsed byte before the returned error. The
@@ -357,12 +507,15 @@ void llhttp_set_error_reason(llhttp_t* parser, const char* reason);
  *
  * Note: this method might be useful for counting the number of parsed bytes.
  */
+LLHTTP_EXPORT
 const char* llhttp_get_error_pos(const llhttp_t* parser);
 
 /* Returns textual name of error code */
+LLHTTP_EXPORT
 const char* llhttp_errno_name(llhttp_errno_t err);
 
 /* Returns textual name of HTTP method */
+LLHTTP_EXPORT
 const char* llhttp_method_name(llhttp_method_t method);
 
 
@@ -375,7 +528,49 @@ const char* llhttp_method_name(llhttp_method_t method);
  *
  * **(USE AT YOUR OWN RISK)**
  */
-void llhttp_set_lenient(llhttp_t* parser, int enabled);
+LLHTTP_EXPORT
+void llhttp_set_lenient_headers(llhttp_t* parser, int enabled);
+
+
+/* Enables/disables lenient handling of conflicting `Transfer-Encoding` and
+ * `Content-Length` headers (disabled by default).
+ *
+ * Normally `llhttp` would error when `Transfer-Encoding` is present in
+ * conjunction with `Content-Length`. This error is important to prevent HTTP
+ * request smuggling, but may be less desirable for small number of cases
+ * involving legacy servers.
+ *
+ * **(USE AT YOUR OWN RISK)**
+ */
+LLHTTP_EXPORT
+void llhttp_set_lenient_chunked_length(llhttp_t* parser, int enabled);
+
+
+/* Enables/disables lenient handling of `Connection: close` and HTTP/1.0
+ * requests responses.
+ *
+ * Normally `llhttp` would error on (in strict mode) or discard (in loose mode)
+ * the HTTP request/response after the request/response with `Connection: close`
+ * and `Content-Length`. This is important to prevent cache poisoning attacks,
+ * but might interact badly with outdated and insecure clients. With this flag
+ * the extra request/response will be parsed normally.
+ *
+ * **(USE AT YOUR OWN RISK)**
+ */
+void llhttp_set_lenient_keep_alive(llhttp_t* parser, int enabled);
+
+/* Enables/disables lenient handling of `Transfer-Encoding` header.
+ *
+ * Normally `llhttp` would error when a `Transfer-Encoding` has `chunked` value
+ * and another value after it (either in a single header or in multiple
+ * headers whose value are internally joined using `, `).
+ * This is mandated by the spec to reliably determine request body size and thus
+ * avoid request smuggling.
+ * With this flag the extra value will be parsed normally.
+ *
+ * **(USE AT YOUR OWN RISK)**
+ */
+void llhttp_set_lenient_transfer_encoding(llhttp_t* parser, int enabled);
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/deps/llhttp/libllhttp.pc.in
+++ b/deps/llhttp/libllhttp.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: libllhttp
+Description: Node.js llhttp Library
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lllhttp
+Cflags: -I${includedir}

--- a/deps/llhttp/llhttp.gyp
+++ b/deps/llhttp/llhttp.gyp
@@ -1,4 +1,11 @@
 {
+  'variables': {
+    'llhttp_sources': [
+      'src/llhttp.c',
+      'src/api.c',
+      'src/http.c',
+    ]
+  },
   'targets': [
     {
       'target_name': 'llhttp',
@@ -7,7 +14,9 @@
       'direct_dependent_settings': {
         'include_dirs': [ 'include' ],
       },
-      'sources': [ 'src/llhttp.c', 'src/api.c', 'src/http.c' ],
+      'sources': [
+        '<@(llhttp_sources)',
+      ],
     },
   ]
 }

--- a/deps/llhttp/src/api.c
+++ b/deps/llhttp/src/api.c
@@ -4,15 +4,30 @@
 
 #include "llhttp.h"
 
-#define CALLBACK_MAYBE(PARSER, NAME, ...)                                     \
+#define CALLBACK_MAYBE(PARSER, NAME)                                          \
   do {                                                                        \
-    llhttp_settings_t* settings;                                              \
-    settings = (llhttp_settings_t*) (PARSER)->settings;                       \
+    const llhttp_settings_t* settings;                                        \
+    settings = (const llhttp_settings_t*) (PARSER)->settings;                 \
     if (settings == NULL || settings->NAME == NULL) {                         \
       err = 0;                                                                \
       break;                                                                  \
     }                                                                         \
-    err = settings->NAME(__VA_ARGS__);                                        \
+    err = settings->NAME((PARSER));                                           \
+  } while (0)
+
+#define SPAN_CALLBACK_MAYBE(PARSER, NAME, START, LEN)                         \
+  do {                                                                        \
+    const llhttp_settings_t* settings;                                        \
+    settings = (const llhttp_settings_t*) (PARSER)->settings;                 \
+    if (settings == NULL || settings->NAME == NULL) {                         \
+      err = 0;                                                                \
+      break;                                                                  \
+    }                                                                         \
+    err = settings->NAME((PARSER), (START), (LEN));                           \
+    if (err == -1) {                                                          \
+      err = HPE_USER;                                                         \
+      llhttp_set_error_reason((PARSER), "Span callback error in " #NAME);     \
+    }                                                                         \
   } while (0)
 
 void llhttp_init(llhttp_t* parser, llhttp_type_t type,
@@ -21,6 +36,91 @@ void llhttp_init(llhttp_t* parser, llhttp_type_t type,
 
   parser->type = type;
   parser->settings = (void*) settings;
+}
+
+
+#if defined(__wasm__)
+
+extern int wasm_on_message_begin(llhttp_t * p);
+extern int wasm_on_url(llhttp_t* p, const char* at, size_t length);
+extern int wasm_on_status(llhttp_t* p, const char* at, size_t length);
+extern int wasm_on_header_field(llhttp_t* p, const char* at, size_t length);
+extern int wasm_on_header_value(llhttp_t* p, const char* at, size_t length);
+extern int wasm_on_headers_complete(llhttp_t * p, int status_code,
+                                    uint8_t upgrade, int should_keep_alive);
+extern int wasm_on_body(llhttp_t* p, const char* at, size_t length);
+extern int wasm_on_message_complete(llhttp_t * p);
+
+static int wasm_on_headers_complete_wrap(llhttp_t* p) {
+  return wasm_on_headers_complete(p, p->status_code, p->upgrade,
+                                  llhttp_should_keep_alive(p));
+}
+
+const llhttp_settings_t wasm_settings = {
+  wasm_on_message_begin,
+  wasm_on_url,
+  wasm_on_status,
+  wasm_on_header_field,
+  wasm_on_header_value,
+  wasm_on_headers_complete_wrap,
+  wasm_on_body,
+  wasm_on_message_complete,
+  NULL,
+  NULL,
+};
+
+
+llhttp_t* llhttp_alloc(llhttp_type_t type) {
+  llhttp_t* parser = malloc(sizeof(llhttp_t));
+  llhttp_init(parser, type, &wasm_settings);
+  return parser;
+}
+
+void llhttp_free(llhttp_t* parser) {
+  free(parser);
+}
+
+/* Some getters required to get stuff from the parser */
+
+uint8_t llhttp_get_type(llhttp_t* parser) {
+  return parser->type;
+}
+
+uint8_t llhttp_get_http_major(llhttp_t* parser) {
+  return parser->http_major;
+}
+
+uint8_t llhttp_get_http_minor(llhttp_t* parser) {
+  return parser->http_minor;
+}
+
+uint8_t llhttp_get_method(llhttp_t* parser) {
+  return parser->method;
+}
+
+int llhttp_get_status_code(llhttp_t* parser) {
+  return parser->status_code;
+}
+
+uint8_t llhttp_get_upgrade(llhttp_t* parser) {
+  return parser->upgrade;
+}
+
+#endif  // defined(__wasm__)
+
+
+void llhttp_reset(llhttp_t* parser) {
+  llhttp_type_t type = parser->type;
+  const llhttp_settings_t* settings = parser->settings;
+  void* data = parser->data;
+  uint8_t lenient_flags = parser->lenient_flags;
+
+  llhttp__internal_init(parser);
+
+  parser->type = type;
+  parser->settings = (void*) settings;
+  parser->data = data;
+  parser->lenient_flags = lenient_flags;
 }
 
 
@@ -44,7 +144,7 @@ llhttp_errno_t llhttp_finish(llhttp_t* parser) {
 
   switch (parser->finish) {
     case HTTP_FINISH_SAFE_WITH_CB:
-      CALLBACK_MAYBE(parser, on_message_complete, parser);
+      CALLBACK_MAYBE(parser, on_message_complete);
       if (err != HPE_OK) return err;
 
     /* FALLTHROUGH */
@@ -120,91 +220,151 @@ const char* llhttp_errno_name(llhttp_errno_t err) {
 const char* llhttp_method_name(llhttp_method_t method) {
 #define HTTP_METHOD_GEN(NUM, NAME, STRING) case HTTP_##NAME: return #STRING;
   switch (method) {
-    HTTP_METHOD_MAP(HTTP_METHOD_GEN)
+    HTTP_ALL_METHOD_MAP(HTTP_METHOD_GEN)
     default: abort();
   }
 #undef HTTP_METHOD_GEN
 }
 
 
-void llhttp_set_lenient(llhttp_t* parser, int enabled) {
+void llhttp_set_lenient_headers(llhttp_t* parser, int enabled) {
   if (enabled) {
-    parser->flags |= F_LENIENT;
+    parser->lenient_flags |= LENIENT_HEADERS;
   } else {
-    parser->flags &= ~F_LENIENT;
+    parser->lenient_flags &= ~LENIENT_HEADERS;
   }
 }
 
+
+void llhttp_set_lenient_chunked_length(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_CHUNKED_LENGTH;
+  } else {
+    parser->lenient_flags &= ~LENIENT_CHUNKED_LENGTH;
+  }
+}
+
+
+void llhttp_set_lenient_keep_alive(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_KEEP_ALIVE;
+  } else {
+    parser->lenient_flags &= ~LENIENT_KEEP_ALIVE;
+  }
+}
+
+void llhttp_set_lenient_transfer_encoding(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->lenient_flags |= LENIENT_TRANSFER_ENCODING;
+  } else {
+    parser->lenient_flags &= ~LENIENT_TRANSFER_ENCODING;
+  }
+}
 
 /* Callbacks */
 
 
 int llhttp__on_message_begin(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_message_begin, s);
+  CALLBACK_MAYBE(s, on_message_begin);
   return err;
 }
 
 
 int llhttp__on_url(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_url, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_url, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_url_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_url_complete);
   return err;
 }
 
 
 int llhttp__on_status(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_status, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_status, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_status_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_status_complete);
   return err;
 }
 
 
 int llhttp__on_header_field(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_header_field, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_header_field, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_header_field_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_header_field_complete);
   return err;
 }
 
 
 int llhttp__on_header_value(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_header_value, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_header_value, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_header_value_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_header_value_complete);
   return err;
 }
 
 
 int llhttp__on_headers_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_headers_complete, s);
+  CALLBACK_MAYBE(s, on_headers_complete);
   return err;
 }
 
 
 int llhttp__on_message_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_message_complete, s);
+  CALLBACK_MAYBE(s, on_message_complete);
   return err;
 }
 
 
 int llhttp__on_body(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_body, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_body, p, endp - p);
   return err;
 }
 
 
 int llhttp__on_chunk_header(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_chunk_header, s);
+  CALLBACK_MAYBE(s, on_chunk_header);
+  return err;
+}
+
+
+int llhttp__on_chunk_parameters(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  SPAN_CALLBACK_MAYBE(s, on_chunk_parameters, p, endp - p);
   return err;
 }
 
 
 int llhttp__on_chunk_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_chunk_complete, s);
+  CALLBACK_MAYBE(s, on_chunk_complete);
   return err;
 }
 

--- a/deps/llhttp/src/http.c
+++ b/deps/llhttp/src/http.c
@@ -51,7 +51,9 @@ int llhttp__after_headers_complete(llhttp_t* parser, const char* p,
     /* chunked encoding - ignore Content-Length header, prepare for a chunk */
     return 2;
   } else if (parser->flags & F_TRANSFER_ENCODING) {
-    if (parser->type == HTTP_REQUEST && (parser->flags & F_LENIENT) == 0) {
+    if (parser->type == HTTP_REQUEST &&
+        (parser->lenient_flags & LENIENT_CHUNKED_LENGTH) == 0 &&
+        (parser->lenient_flags & LENIENT_TRANSFER_ENCODING) == 0) {
       /* RFC 7230 3.3.3 */
 
       /* If a Transfer-Encoding header field
@@ -97,9 +99,7 @@ int llhttp__after_message_complete(llhttp_t* parser, const char* p,
 
   should_keep_alive = llhttp_should_keep_alive(parser);
   parser->finish = HTTP_FINISH_SAFE;
-
-  /* Keep `F_LENIENT` flag between messages, but reset every other flag */
-  parser->flags &= F_LENIENT;
+  parser->flags = 0;
 
   /* NOTE: this is ignored in loose parsing mode */
   return should_keep_alive;

--- a/deps/llhttp/src/llhttp.c
+++ b/deps/llhttp/src/llhttp.c
@@ -24,164 +24,197 @@ typedef int (*llhttp__internal__span_cb)(
              llhttp__internal_t*, const char*, const char*);
 
 static const unsigned char llparse_blob0[] = {
-  'C', 'L'
-};
-static const unsigned char llparse_blob1[] = {
   0xd, 0xa
 };
-static const unsigned char llparse_blob2[] = {
+static const unsigned char llparse_blob1[] = {
   'o', 'n'
 };
-static const unsigned char llparse_blob3[] = {
+static const unsigned char llparse_blob2[] = {
   'e', 'c', 't', 'i', 'o', 'n'
 };
-static const unsigned char llparse_blob4[] = {
+static const unsigned char llparse_blob3[] = {
   'l', 'o', 's', 'e'
 };
-static const unsigned char llparse_blob5[] = {
+static const unsigned char llparse_blob4[] = {
   'e', 'e', 'p', '-', 'a', 'l', 'i', 'v', 'e'
 };
-static const unsigned char llparse_blob6[] = {
+static const unsigned char llparse_blob5[] = {
   'p', 'g', 'r', 'a', 'd', 'e'
 };
-static const unsigned char llparse_blob7[] = {
+static const unsigned char llparse_blob6[] = {
   'c', 'h', 'u', 'n', 'k', 'e', 'd'
 };
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob8[] = {
+static const unsigned char ALIGN(16) llparse_blob7[] = {
   0x9, 0x9, ' ', '~', 0x80, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0,
   0x0, 0x0, 0x0, 0x0, 0x0
 };
 #endif  /* __SSE4_2__ */
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob9[] = {
+static const unsigned char ALIGN(16) llparse_blob8[] = {
   '!', '!', '#', '\'', '*', '+', '-', '.', '0', '9', 'A',
   'Z', '^', 'z', '|', '|'
 };
 #endif  /* __SSE4_2__ */
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob10[] = {
+static const unsigned char ALIGN(16) llparse_blob9[] = {
   '~', '~', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
   0x0, 0x0, 0x0, 0x0, 0x0
 };
 #endif  /* __SSE4_2__ */
-static const unsigned char llparse_blob11[] = {
+static const unsigned char llparse_blob10[] = {
   'e', 'n', 't', '-', 'l', 'e', 'n', 'g', 't', 'h'
 };
-static const unsigned char llparse_blob12[] = {
+static const unsigned char llparse_blob11[] = {
   'r', 'o', 'x', 'y', '-', 'c', 'o', 'n', 'n', 'e', 'c',
   't', 'i', 'o', 'n'
 };
-static const unsigned char llparse_blob13[] = {
+static const unsigned char llparse_blob12[] = {
   'r', 'a', 'n', 's', 'f', 'e', 'r', '-', 'e', 'n', 'c',
   'o', 'd', 'i', 'n', 'g'
 };
-static const unsigned char llparse_blob14[] = {
+static const unsigned char llparse_blob13[] = {
   'p', 'g', 'r', 'a', 'd', 'e'
 };
-static const unsigned char llparse_blob15[] = {
+static const unsigned char llparse_blob14[] = {
   'T', 'T', 'P', '/'
+};
+static const unsigned char llparse_blob15[] = {
+  0xd, 0xa, 0xd, 0xa, 'S', 'M', 0xd, 0xa, 0xd, 0xa
 };
 static const unsigned char llparse_blob16[] = {
   'C', 'E', '/'
 };
 static const unsigned char llparse_blob17[] = {
-  'I', 'N', 'D'
+  'T', 'S', 'P', '/'
 };
 static const unsigned char llparse_blob18[] = {
-  'E', 'C', 'K', 'O', 'U', 'T'
+  'N', 'O', 'U', 'N', 'C', 'E'
 };
 static const unsigned char llparse_blob19[] = {
-  'N', 'E', 'C', 'T'
+  'I', 'N', 'D'
 };
 static const unsigned char llparse_blob20[] = {
-  'E', 'L', 'E', 'T', 'E'
+  'E', 'C', 'K', 'O', 'U', 'T'
 };
 static const unsigned char llparse_blob21[] = {
-  'E', 'T'
+  'N', 'E', 'C', 'T'
 };
 static const unsigned char llparse_blob22[] = {
-  'E', 'A', 'D'
+  'E', 'T', 'E'
 };
 static const unsigned char llparse_blob23[] = {
-  'N', 'K'
+  'C', 'R', 'I', 'B', 'E'
 };
 static const unsigned char llparse_blob24[] = {
-  'C', 'K'
+  'L', 'U', 'S', 'H'
 };
 static const unsigned char llparse_blob25[] = {
-  'S', 'E', 'A', 'R', 'C', 'H'
+  'E', 'T'
 };
 static const unsigned char llparse_blob26[] = {
-  'R', 'G', 'E'
+  'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
 };
 static const unsigned char llparse_blob27[] = {
-  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
+  'E', 'A', 'D'
 };
 static const unsigned char llparse_blob28[] = {
-  'L', 'E', 'N', 'D', 'A', 'R'
-};
-static const unsigned char llparse_blob29[] = {
-  'V', 'E'
-};
-static const unsigned char llparse_blob30[] = {
-  'O', 'T', 'I', 'F', 'Y'
-};
-static const unsigned char llparse_blob31[] = {
-  'P', 'T', 'I', 'O', 'N', 'S'
-};
-static const unsigned char llparse_blob32[] = {
-  'T', 'C', 'H'
-};
-static const unsigned char llparse_blob33[] = {
-  'S', 'T'
-};
-static const unsigned char llparse_blob34[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob35[] = {
-  'A', 'T', 'C', 'H'
-};
-static const unsigned char llparse_blob36[] = {
-  'G', 'E'
-};
-static const unsigned char llparse_blob37[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob38[] = {
-  'O', 'R', 'T'
-};
-static const unsigned char llparse_blob39[] = {
-  'A', 'R', 'C', 'H'
-};
-static const unsigned char llparse_blob40[] = {
-  'U', 'R', 'C', 'E'
-};
-static const unsigned char llparse_blob41[] = {
-  'B', 'S', 'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob42[] = {
-  'R', 'A', 'C', 'E'
-};
-static const unsigned char llparse_blob43[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob44[] = {
   'N', 'K'
 };
-static const unsigned char llparse_blob45[] = {
+static const unsigned char llparse_blob29[] = {
   'C', 'K'
 };
+static const unsigned char llparse_blob30[] = {
+  'S', 'E', 'A', 'R', 'C', 'H'
+};
+static const unsigned char llparse_blob31[] = {
+  'R', 'G', 'E'
+};
+static const unsigned char llparse_blob32[] = {
+  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
+};
+static const unsigned char llparse_blob33[] = {
+  'L', 'E', 'N', 'D', 'A', 'R'
+};
+static const unsigned char llparse_blob34[] = {
+  'V', 'E'
+};
+static const unsigned char llparse_blob35[] = {
+  'O', 'T', 'I', 'F', 'Y'
+};
+static const unsigned char llparse_blob36[] = {
+  'P', 'T', 'I', 'O', 'N', 'S'
+};
+static const unsigned char llparse_blob37[] = {
+  'C', 'H'
+};
+static const unsigned char llparse_blob38[] = {
+  'S', 'E'
+};
+static const unsigned char llparse_blob39[] = {
+  'A', 'Y'
+};
+static const unsigned char llparse_blob40[] = {
+  'S', 'T'
+};
+static const unsigned char llparse_blob41[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob42[] = {
+  'A', 'T', 'C', 'H'
+};
+static const unsigned char llparse_blob43[] = {
+  'G', 'E'
+};
+static const unsigned char llparse_blob44[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob45[] = {
+  'O', 'R', 'D'
+};
 static const unsigned char llparse_blob46[] = {
-  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
+  'I', 'R', 'E', 'C', 'T'
 };
 static const unsigned char llparse_blob47[] = {
-  'H', 'T', 'T', 'P', '/'
+  'O', 'R', 'T'
 };
 static const unsigned char llparse_blob48[] = {
-  'A', 'D'
+  'R', 'C', 'H'
 };
 static const unsigned char llparse_blob49[] = {
+  'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
+};
+static const unsigned char llparse_blob50[] = {
+  'U', 'R', 'C', 'E'
+};
+static const unsigned char llparse_blob51[] = {
+  'B', 'S', 'C', 'R', 'I', 'B', 'E'
+};
+static const unsigned char llparse_blob52[] = {
+  'A', 'R', 'D', 'O', 'W', 'N'
+};
+static const unsigned char llparse_blob53[] = {
+  'A', 'C', 'E'
+};
+static const unsigned char llparse_blob54[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob55[] = {
+  'N', 'K'
+};
+static const unsigned char llparse_blob56[] = {
+  'C', 'K'
+};
+static const unsigned char llparse_blob57[] = {
+  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
+};
+static const unsigned char llparse_blob58[] = {
+  'H', 'T', 'T', 'P', '/'
+};
+static const unsigned char llparse_blob59[] = {
+  'A', 'D'
+};
+static const unsigned char llparse_blob60[] = {
   'T', 'P', '/'
 };
 
@@ -307,6 +340,8 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_invoke_is_equal_content_length,
   s_n_llhttp__internal__n_chunk_size_almost_done,
   s_n_llhttp__internal__n_chunk_parameters,
+  s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters,
+  s_n_llhttp__internal__n_chunk_parameters_ows,
   s_n_llhttp__internal__n_chunk_size_otherwise,
   s_n_llhttp__internal__n_chunk_size,
   s_n_llhttp__internal__n_chunk_size_digit,
@@ -318,7 +353,8 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete,
   s_n_llhttp__internal__n_headers_almost_done,
   s_n_llhttp__internal__n_header_field_colon_discard_ws,
-  s_n_llhttp__internal__n_error_20,
+  s_n_llhttp__internal__n_error_19,
+  s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_value,
   s_n_llhttp__internal__n_header_value_discard_lws,
   s_n_llhttp__internal__n_header_value_discard_ws_almost_done,
@@ -346,6 +382,7 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_te_chunked,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
   s_n_llhttp__internal__n_header_value_discard_ws,
+  s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete,
   s_n_llhttp__internal__n_header_field_general_otherwise,
   s_n_llhttp__internal__n_header_field_general,
   s_n_llhttp__internal__n_header_field_colon,
@@ -363,13 +400,15 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_url_skip_to_http09,
   s_n_llhttp__internal__n_url_skip_lf_to_http09_1,
   s_n_llhttp__internal__n_url_skip_lf_to_http09,
-  s_n_llhttp__internal__n_req_http_end_1,
-  s_n_llhttp__internal__n_req_http_end,
+  s_n_llhttp__internal__n_req_pri_upgrade,
+  s_n_llhttp__internal__n_req_http_complete_1,
+  s_n_llhttp__internal__n_req_http_complete,
   s_n_llhttp__internal__n_req_http_minor,
   s_n_llhttp__internal__n_req_http_dot,
   s_n_llhttp__internal__n_req_http_major,
   s_n_llhttp__internal__n_req_http_start_1,
   s_n_llhttp__internal__n_req_http_start_2,
+  s_n_llhttp__internal__n_req_http_start_3,
   s_n_llhttp__internal__n_req_http_start,
   s_n_llhttp__internal__n_url_to_http,
   s_n_llhttp__internal__n_url_skip_to_http,
@@ -394,57 +433,77 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_url_entry_connect,
   s_n_llhttp__internal__n_req_spaces_before_url,
   s_n_llhttp__internal__n_req_first_space_before_url,
-  s_n_llhttp__internal__n_start_req_1,
   s_n_llhttp__internal__n_start_req_2,
+  s_n_llhttp__internal__n_start_req_3,
+  s_n_llhttp__internal__n_start_req_1,
   s_n_llhttp__internal__n_start_req_4,
   s_n_llhttp__internal__n_start_req_6,
-  s_n_llhttp__internal__n_start_req_7,
-  s_n_llhttp__internal__n_start_req_5,
-  s_n_llhttp__internal__n_start_req_3,
   s_n_llhttp__internal__n_start_req_8,
   s_n_llhttp__internal__n_start_req_9,
-  s_n_llhttp__internal__n_start_req_10,
+  s_n_llhttp__internal__n_start_req_7,
+  s_n_llhttp__internal__n_start_req_5,
   s_n_llhttp__internal__n_start_req_12,
   s_n_llhttp__internal__n_start_req_13,
   s_n_llhttp__internal__n_start_req_11,
-  s_n_llhttp__internal__n_start_req_15,
+  s_n_llhttp__internal__n_start_req_10,
+  s_n_llhttp__internal__n_start_req_14,
+  s_n_llhttp__internal__n_start_req_17,
   s_n_llhttp__internal__n_start_req_16,
+  s_n_llhttp__internal__n_start_req_15,
   s_n_llhttp__internal__n_start_req_18,
   s_n_llhttp__internal__n_start_req_20,
   s_n_llhttp__internal__n_start_req_21,
   s_n_llhttp__internal__n_start_req_19,
-  s_n_llhttp__internal__n_start_req_17,
-  s_n_llhttp__internal__n_start_req_22,
-  s_n_llhttp__internal__n_start_req_14,
   s_n_llhttp__internal__n_start_req_23,
   s_n_llhttp__internal__n_start_req_24,
   s_n_llhttp__internal__n_start_req_26,
+  s_n_llhttp__internal__n_start_req_28,
+  s_n_llhttp__internal__n_start_req_29,
   s_n_llhttp__internal__n_start_req_27,
+  s_n_llhttp__internal__n_start_req_25,
+  s_n_llhttp__internal__n_start_req_30,
+  s_n_llhttp__internal__n_start_req_22,
   s_n_llhttp__internal__n_start_req_31,
   s_n_llhttp__internal__n_start_req_32,
-  s_n_llhttp__internal__n_start_req_30,
-  s_n_llhttp__internal__n_start_req_29,
-  s_n_llhttp__internal__n_start_req_28,
+  s_n_llhttp__internal__n_start_req_35,
+  s_n_llhttp__internal__n_start_req_36,
   s_n_llhttp__internal__n_start_req_34,
-  s_n_llhttp__internal__n_start_req_33,
-  s_n_llhttp__internal__n_start_req_25,
   s_n_llhttp__internal__n_start_req_37,
   s_n_llhttp__internal__n_start_req_38,
-  s_n_llhttp__internal__n_start_req_36,
-  s_n_llhttp__internal__n_start_req_35,
-  s_n_llhttp__internal__n_start_req_40,
-  s_n_llhttp__internal__n_start_req_41,
   s_n_llhttp__internal__n_start_req_42,
-  s_n_llhttp__internal__n_start_req_39,
   s_n_llhttp__internal__n_start_req_43,
-  s_n_llhttp__internal__n_start_req_46,
-  s_n_llhttp__internal__n_start_req_48,
-  s_n_llhttp__internal__n_start_req_49,
-  s_n_llhttp__internal__n_start_req_47,
-  s_n_llhttp__internal__n_start_req_50,
+  s_n_llhttp__internal__n_start_req_41,
+  s_n_llhttp__internal__n_start_req_40,
+  s_n_llhttp__internal__n_start_req_39,
   s_n_llhttp__internal__n_start_req_45,
   s_n_llhttp__internal__n_start_req_44,
+  s_n_llhttp__internal__n_start_req_33,
+  s_n_llhttp__internal__n_start_req_48,
+  s_n_llhttp__internal__n_start_req_49,
+  s_n_llhttp__internal__n_start_req_50,
+  s_n_llhttp__internal__n_start_req_51,
+  s_n_llhttp__internal__n_start_req_47,
+  s_n_llhttp__internal__n_start_req_46,
+  s_n_llhttp__internal__n_start_req_54,
+  s_n_llhttp__internal__n_start_req_56,
+  s_n_llhttp__internal__n_start_req_57,
+  s_n_llhttp__internal__n_start_req_55,
+  s_n_llhttp__internal__n_start_req_53,
+  s_n_llhttp__internal__n_start_req_58,
+  s_n_llhttp__internal__n_start_req_59,
+  s_n_llhttp__internal__n_start_req_52,
+  s_n_llhttp__internal__n_start_req_61,
+  s_n_llhttp__internal__n_start_req_62,
+  s_n_llhttp__internal__n_start_req_60,
+  s_n_llhttp__internal__n_start_req_65,
+  s_n_llhttp__internal__n_start_req_67,
+  s_n_llhttp__internal__n_start_req_68,
+  s_n_llhttp__internal__n_start_req_66,
+  s_n_llhttp__internal__n_start_req_69,
+  s_n_llhttp__internal__n_start_req_64,
+  s_n_llhttp__internal__n_start_req_63,
   s_n_llhttp__internal__n_start_req,
+  s_n_llhttp__internal__n_invoke_llhttp__on_status_complete,
   s_n_llhttp__internal__n_res_line_almost_done,
   s_n_llhttp__internal__n_res_status,
   s_n_llhttp__internal__n_span_start_llhttp__on_status,
@@ -479,6 +538,10 @@ int llhttp__on_header_value(
     const unsigned char* endp);
 
 int llhttp__on_body(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_chunk_parameters(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
@@ -537,6 +600,10 @@ int llhttp__internal__c_update_http_minor(
   return 0;
 }
 
+int llhttp__on_url_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
 int llhttp__internal__c_test_flags(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -571,6 +638,13 @@ int llhttp__internal__c_update_finish_1(
   return 0;
 }
 
+int llhttp__internal__c_test_lenient_flags(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 4) == 4;
+}
+
 int llhttp__internal__c_test_flags_1(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -578,18 +652,11 @@ int llhttp__internal__c_test_flags_1(
   return (state->flags & 544) == 544;
 }
 
-int llhttp__internal__c_test_flags_2(
+int llhttp__internal__c_test_lenient_flags_1(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
-  return (state->flags & 256) == 256;
-}
-
-int llhttp__internal__c_test_flags_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 40) == 40;
+  return (state->lenient_flags & 2) == 2;
 }
 
 int llhttp__before_headers_complete(
@@ -690,6 +757,17 @@ int llhttp__internal__c_store_header_state(
   return 0;
 }
 
+int llhttp__internal__c_test_lenient_flags_2(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 1) == 1;
+}
+
+int llhttp__on_header_field_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
 int llhttp__internal__c_load_header_state(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -712,6 +790,10 @@ int llhttp__internal__c_update_header_state(
   state->header_state = 1;
   return 0;
 }
+
+int llhttp__on_header_value_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
 
 int llhttp__internal__c_or_flags_4(
     llhttp__internal_t* state,
@@ -769,7 +851,7 @@ int llhttp__internal__c_update_header_state_7(
   return 0;
 }
 
-int llhttp__internal__c_test_flags_7(
+int llhttp__internal__c_test_flags_2(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -810,11 +892,18 @@ int llhttp__internal__c_or_flags_15(
   return 0;
 }
 
-int llhttp__internal__c_test_flags_8(
+int llhttp__internal__c_test_flags_3(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
   return (state->flags & 8) == 8;
+}
+
+int llhttp__internal__c_test_lenient_flags_7(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 8) == 8;
 }
 
 int llhttp__internal__c_or_flags_16(
@@ -849,6 +938,13 @@ int llhttp__internal__c_or_flags_18(
   return 0;
 }
 
+int llhttp__internal__c_load_method(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->method;
+}
+
 int llhttp__internal__c_store_http_major(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -867,11 +963,25 @@ int llhttp__internal__c_store_http_minor(
   return 0;
 }
 
-int llhttp__internal__c_is_equal_method_1(
+int llhttp__internal__c_test_lenient_flags_9(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
-  return state->method == 33;
+  return (state->lenient_flags & 16) == 16;
+}
+
+int llhttp__internal__c_load_http_major(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->http_major;
+}
+
+int llhttp__internal__c_load_http_minor(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->http_minor;
 }
 
 int llhttp__internal__c_update_status_code(
@@ -912,6 +1022,10 @@ int llhttp__internal__c_mul_add_status_code(
   }
   return 0;
 }
+
+int llhttp__on_status_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
 
 int llhttp__internal__c_update_type(
     llhttp__internal_t* state,
@@ -1015,7 +1129,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_chunk_data_almost_done;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob1, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob0, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -1118,11 +1232,38 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_chunk_parameters;
         }
         case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_parameters;
         }
         default: {
           goto s_n_llhttp__internal__n_error_10;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters:
+    s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_chunk_parameters;
+      goto s_n_llhttp__internal__n_chunk_parameters;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_parameters_ows:
+    s_n_llhttp__internal__n_chunk_parameters_ows: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_parameters_ows;
+      }
+      switch (*p) {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_parameters_ows;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters;
         }
       }
       /* UNREACHABLE */;
@@ -1138,13 +1279,9 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_chunk_size_almost_done;
         }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
-        }
         case ';': {
           p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
+          goto s_n_llhttp__internal__n_chunk_parameters_ows;
         }
         default: {
           goto s_n_llhttp__internal__n_error_11;
@@ -1488,7 +1625,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_test_flags;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_19;
+          goto s_n_llhttp__internal__n_error_18;
         }
       }
       /* UNREACHABLE */;
@@ -1511,13 +1648,22 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_20:
-    s_n_llhttp__internal__n_error_20: {
+    case s_n_llhttp__internal__n_error_19:
+    s_n_llhttp__internal__n_error_19: {
       state->error = 0xa;
       state->reason = "Invalid header field char";
       state->error_pos = (const char*) p;
       state->_current = (void*) (intptr_t) s_error;
       return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete: {
+      switch (llhttp__on_header_value_complete(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_header_field_start;
+      }
       /* UNREACHABLE */;
       abort();
     }
@@ -1540,11 +1686,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
         }
         default: {
           goto s_n_llhttp__internal__n_invoke_load_header_state;
@@ -1564,7 +1710,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_discard_lws;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_23;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
         }
       }
       /* UNREACHABLE */;
@@ -1646,7 +1792,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_test_flags_6;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_6;
         }
       }
       /* UNREACHABLE */;
@@ -1725,7 +1871,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_1;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob4, 4);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob3, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -1749,7 +1895,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_2;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob5, 9);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob4, 9);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -1773,7 +1919,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_3;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob6, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob5, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2002,7 +2148,7 @@ static llparse_state_t llhttp__internal__run(
       
         /* Load input */
         input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob8);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob7);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 6,
@@ -2101,7 +2247,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_te_chunked;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob7, 7);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob6, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2141,7 +2287,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_3;
         }
         case 13: {
           p++;
@@ -2154,6 +2300,15 @@ static llparse_state_t llhttp__internal__run(
         default: {
           goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
         }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete: {
+      switch (llhttp__on_header_field_complete(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_header_value_discard_ws;
       }
       /* UNREACHABLE */;
       abort();
@@ -2206,7 +2361,7 @@ static llparse_state_t llhttp__internal__run(
       
         /* Load input */
         input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob9);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob8);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 16,
@@ -2218,7 +2373,7 @@ static llparse_state_t llhttp__internal__run(
           p += match_len;
           goto s_n_llhttp__internal__n_header_field_general;
         }
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob10);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob9);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 2,
@@ -2252,7 +2407,7 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case ' ': {
-          goto s_n_llhttp__internal__n_invoke_test_flags_4;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_2;
         }
         case ':': {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
@@ -2271,7 +2426,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_3;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob3, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob2, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2296,7 +2451,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_4;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob11, 10);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob10, 10);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2342,7 +2497,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_1;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob2, 2);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob1, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2366,7 +2521,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_5;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob12, 15);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob11, 15);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2391,7 +2546,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_6;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob13, 16);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob12, 16);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2416,7 +2571,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_7;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob14, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob13, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -2579,10 +2734,34 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_req_http_end_1:
-    s_n_llhttp__internal__n_req_http_end_1: {
+    case s_n_llhttp__internal__n_req_pri_upgrade:
+    s_n_llhttp__internal__n_req_pri_upgrade: {
+      llparse_match_t match_seq;
+      
       if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_end_1;
+        return s_n_llhttp__internal__n_req_pri_upgrade;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 10);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_error_37;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_req_pri_upgrade;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_38;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_complete_1:
+    s_n_llhttp__internal__n_req_http_complete_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_complete_1;
       }
       switch (*p) {
         case 10: {
@@ -2590,16 +2769,16 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_field_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_33;
+          goto s_n_llhttp__internal__n_error_36;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_req_http_end:
-    s_n_llhttp__internal__n_req_http_end: {
+    case s_n_llhttp__internal__n_req_http_complete:
+    s_n_llhttp__internal__n_req_http_complete: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_end;
+        return s_n_llhttp__internal__n_req_http_complete;
       }
       switch (*p) {
         case 10: {
@@ -2608,10 +2787,10 @@ static llparse_state_t llhttp__internal__run(
         }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_req_http_end_1;
+          goto s_n_llhttp__internal__n_req_http_complete_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_33;
+          goto s_n_llhttp__internal__n_error_36;
         }
       }
       /* UNREACHABLE */;
@@ -2674,7 +2853,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_34;
+          goto s_n_llhttp__internal__n_error_41;
         }
       }
       /* UNREACHABLE */;
@@ -2691,7 +2870,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_35;
+          goto s_n_llhttp__internal__n_error_42;
         }
       }
       /* UNREACHABLE */;
@@ -2754,7 +2933,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_major;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_36;
+          goto s_n_llhttp__internal__n_error_43;
         }
       }
       /* UNREACHABLE */;
@@ -2767,18 +2946,18 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_http_start_1;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob14, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_req_http_major;
+          goto s_n_llhttp__internal__n_invoke_load_method;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_req_http_start_1;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_38;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -2796,13 +2975,37 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_is_equal_method_1;
+          goto s_n_llhttp__internal__n_invoke_load_method_2;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_req_http_start_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_38;
+          goto s_n_llhttp__internal__n_error_46;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_start_3:
+    s_n_llhttp__internal__n_req_http_start_3: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_start_3;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_load_method_3;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_req_http_start_3;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -2826,8 +3029,12 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_req_http_start_2;
         }
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_req_http_start_3;
+        }
         default: {
-          goto s_n_llhttp__internal__n_error_38;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -2848,7 +3055,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_error_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_req_http_start;
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1;
         }
       }
       /* UNREACHABLE */;
@@ -2918,7 +3125,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_fragment;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_39;
+          goto s_n_llhttp__internal__n_error_47;
         }
       }
       /* UNREACHABLE */;
@@ -2979,7 +3186,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_stub_query_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_40;
+          goto s_n_llhttp__internal__n_error_48;
         }
       }
       /* UNREACHABLE */;
@@ -3017,7 +3224,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_query;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_41;
+          goto s_n_llhttp__internal__n_error_49;
         }
       }
       /* UNREACHABLE */;
@@ -3142,10 +3349,10 @@ static llparse_state_t llhttp__internal__run(
         }
         case 8: {
           p++;
-          goto s_n_llhttp__internal__n_error_42;
+          goto s_n_llhttp__internal__n_error_50;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
+          goto s_n_llhttp__internal__n_error_51;
         }
       }
       /* UNREACHABLE */;
@@ -3204,7 +3411,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server_with_at;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_44;
+          goto s_n_llhttp__internal__n_error_52;
         }
       }
       /* UNREACHABLE */;
@@ -3221,7 +3428,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_46;
+          goto s_n_llhttp__internal__n_error_54;
         }
       }
       /* UNREACHABLE */;
@@ -3239,7 +3446,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_53;
         }
         case 12: {
           p++;
@@ -3247,18 +3454,18 @@ static llparse_state_t llhttp__internal__run(
         }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_53;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_53;
         }
         case '/': {
           p++;
           goto s_n_llhttp__internal__n_url_schema_delim_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_46;
+          goto s_n_llhttp__internal__n_error_54;
         }
       }
       /* UNREACHABLE */;
@@ -3304,7 +3511,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case 2: {
           p++;
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_53;
         }
         case 3: {
           goto s_n_llhttp__internal__n_span_end_stub_schema;
@@ -3314,7 +3521,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_47;
+          goto s_n_llhttp__internal__n_error_55;
         }
       }
       /* UNREACHABLE */;
@@ -3350,7 +3557,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case 2: {
           p++;
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_53;
         }
         case 3: {
           goto s_n_llhttp__internal__n_span_start_stub_path_2;
@@ -3359,7 +3566,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_48;
+          goto s_n_llhttp__internal__n_error_56;
         }
       }
       /* UNREACHABLE */;
@@ -3457,32 +3664,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_spaces_before_url;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_49;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_1:
-    s_n_llhttp__internal__n_start_req_1: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_1;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob0, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 19;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_1;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_57;
         }
       }
       /* UNREACHABLE */;
@@ -3490,24 +3672,63 @@ static llparse_state_t llhttp__internal__run(
     }
     case s_n_llhttp__internal__n_start_req_2:
     s_n_llhttp__internal__n_start_req_2: {
-      llparse_match_t match_seq;
-      
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob17, 3);
+      switch (*p) {
+        case 'L': {
+          p++;
+          match = 19;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_3:
+    s_n_llhttp__internal__n_start_req_3: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_3;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 16;
+          match = 36;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_2;
+          return s_n_llhttp__internal__n_start_req_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_1:
+    s_n_llhttp__internal__n_start_req_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_1;
+      }
+      switch (*p) {
+        case 'C': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_2;
+        }
+        case 'N': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_3;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3520,19 +3741,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_4;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 22;
+          match = 16;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_4;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3545,79 +3766,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_6;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 5;
+          match = 22;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_6;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_7:
-    s_n_llhttp__internal__n_start_req_7: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_7;
-      }
-      switch (*p) {
-        case 'Y': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_5:
-    s_n_llhttp__internal__n_start_req_5: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_5;
-      }
-      switch (*p) {
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_6;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_7;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_3:
-    s_n_llhttp__internal__n_start_req_3: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_3;
-      }
-      switch (*p) {
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_4;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_5;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3630,19 +3791,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_8;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 0;
+          match = 5;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_8;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3650,49 +3811,59 @@ static llparse_state_t llhttp__internal__run(
     }
     case s_n_llhttp__internal__n_start_req_9:
     s_n_llhttp__internal__n_start_req_9: {
-      llparse_match_t match_seq;
-      
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_9;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
+      switch (*p) {
+        case 'Y': {
           p++;
-          match = 1;
+          match = 8;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_9;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_10:
-    s_n_llhttp__internal__n_start_req_10: {
-      llparse_match_t match_seq;
-      
+    case s_n_llhttp__internal__n_start_req_7:
+    s_n_llhttp__internal__n_start_req_7: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_10;
+        return s_n_llhttp__internal__n_start_req_7;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
+      switch (*p) {
+        case 'N': {
           p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
+          goto s_n_llhttp__internal__n_start_req_8;
         }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_10;
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_9;
         }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_5:
+    s_n_llhttp__internal__n_start_req_5: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_5;
+      }
+      switch (*p) {
+        case 'H': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_6;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_7;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3705,19 +3876,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_12;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 31;
+          match = 0;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_12;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3730,19 +3901,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_13;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 9;
+          match = 35;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_13;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3754,16 +3925,101 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_start_req_11;
       }
       switch (*p) {
-        case 'I': {
+        case 'L': {
           p++;
           goto s_n_llhttp__internal__n_start_req_12;
         }
-        case 'O': {
+        case 'S': {
           p++;
           goto s_n_llhttp__internal__n_start_req_13;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_10:
+    s_n_llhttp__internal__n_start_req_10: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_10;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_11;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_14:
+    s_n_llhttp__internal__n_start_req_14: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_14;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 45;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_14;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_17:
+    s_n_llhttp__internal__n_start_req_17: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_17;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 9);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 41;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_17;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_16:
+    s_n_llhttp__internal__n_start_req_16: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_16;
+      }
+      switch (*p) {
+        case '_': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_17;
+        }
+        default: {
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
       }
       /* UNREACHABLE */;
@@ -3776,44 +4032,18 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_15;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 24;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
+          goto s_n_llhttp__internal__n_start_req_16;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_15;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_16:
-    s_n_llhttp__internal__n_start_req_16: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_16;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 23;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_16;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3826,19 +4056,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_18;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 7);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 21;
+          match = 2;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_18;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3851,19 +4081,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_20;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 30;
+          match = 31;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_20;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3871,17 +4101,24 @@ static llparse_state_t llhttp__internal__run(
     }
     case s_n_llhttp__internal__n_start_req_21:
     s_n_llhttp__internal__n_start_req_21: {
+      llparse_match_t match_seq;
+      
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_21;
       }
-      switch (*p) {
-        case 'L': {
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
           p++;
-          match = 10;
+          match = 9;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_21;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3893,7 +4130,7 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_start_req_19;
       }
       switch (*p) {
-        case 'A': {
+        case 'I': {
           p++;
           goto s_n_llhttp__internal__n_start_req_20;
         }
@@ -3902,82 +4139,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_21;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_17:
-    s_n_llhttp__internal__n_start_req_17: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_17;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_18;
-        }
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_19;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_22:
-    s_n_llhttp__internal__n_start_req_22: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_22;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_22;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_14:
-    s_n_llhttp__internal__n_start_req_14: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_14;
-      }
-      switch (*p) {
-        case '-': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_15;
-        }
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_16;
-        }
-        case 'K': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_17;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_22;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -3990,19 +4152,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_23;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 25;
+          match = 24;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_23;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4015,19 +4177,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_24;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 6;
+          match = 23;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_24;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4040,115 +4202,44 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_26;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 28;
+          match = 21;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_26;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_27:
-    s_n_llhttp__internal__n_start_req_27: {
+    case s_n_llhttp__internal__n_start_req_28:
+    s_n_llhttp__internal__n_start_req_28: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_27;
+        return s_n_llhttp__internal__n_start_req_28;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 3;
+          match = 30;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_27;
+          return s_n_llhttp__internal__n_start_req_28;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_31:
-    s_n_llhttp__internal__n_start_req_31: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_31;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_31;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_32:
-    s_n_llhttp__internal__n_start_req_32: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_32;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_32;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_30:
-    s_n_llhttp__internal__n_start_req_30: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_30;
-      }
-      switch (*p) {
-        case 'F': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_31;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_32;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4160,81 +4251,34 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_start_req_29;
       }
       switch (*p) {
-        case 'P': {
+        case 'L': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_30;
+          match = 10;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_28:
-    s_n_llhttp__internal__n_start_req_28: {
+    case s_n_llhttp__internal__n_start_req_27:
+    s_n_llhttp__internal__n_start_req_27: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_28;
+        return s_n_llhttp__internal__n_start_req_27;
       }
       switch (*p) {
-        case 'I': {
+        case 'A': {
           p++;
-          match = 34;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
+          goto s_n_llhttp__internal__n_start_req_28;
         }
         case 'O': {
           p++;
           goto s_n_llhttp__internal__n_start_req_29;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_34:
-    s_n_llhttp__internal__n_start_req_34: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_34;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 29;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_34;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_33:
-    s_n_llhttp__internal__n_start_req_33: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_33;
-      }
-      switch (*p) {
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_34;
-        }
-        case 'T': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4250,20 +4294,187 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_start_req_26;
         }
-        case 'O': {
+        case 'C': {
           p++;
           goto s_n_llhttp__internal__n_start_req_27;
         }
-        case 'R': {
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_30:
+    s_n_llhttp__internal__n_start_req_30: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_30;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_start_req_28;
+          match = 11;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_30;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_22:
+    s_n_llhttp__internal__n_start_req_22: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_22;
+      }
+      switch (*p) {
+        case '-': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_23;
+        }
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_24;
+        }
+        case 'K': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_25;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_30;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_31:
+    s_n_llhttp__internal__n_start_req_31: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_31;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 5);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 25;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_31;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_32:
+    s_n_llhttp__internal__n_start_req_32: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_32;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_32;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_35:
+    s_n_llhttp__internal__n_start_req_35: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_35;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 28;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_35;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_36:
+    s_n_llhttp__internal__n_start_req_36: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_36;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 39;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_36;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_34:
+    s_n_llhttp__internal__n_start_req_34: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_34;
+      }
+      switch (*p) {
+        case 'T': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_35;
         }
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_33;
+          goto s_n_llhttp__internal__n_start_req_36;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4276,19 +4487,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_37;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 17;
+          match = 38;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_37;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4301,107 +4512,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_38;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 20;
+          match = 3;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_38;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_36:
-    s_n_llhttp__internal__n_start_req_36: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_36;
-      }
-      switch (*p) {
-        case 'B': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_37;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_38;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_35:
-    s_n_llhttp__internal__n_start_req_35: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_35;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_36;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_40:
-    s_n_llhttp__internal__n_start_req_40: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_40;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_40;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_41:
-    s_n_llhttp__internal__n_start_req_41: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_41;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 33;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_41;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4414,44 +4537,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_42;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 7);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 26;
+          match = 12;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_42;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_39:
-    s_n_llhttp__internal__n_start_req_39: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_39;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_40;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_41;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_42;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4469,39 +4567,154 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 7;
+          match = 13;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_43;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_46:
-    s_n_llhttp__internal__n_start_req_46: {
+    case s_n_llhttp__internal__n_start_req_41:
+    s_n_llhttp__internal__n_start_req_41: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_41;
+      }
+      switch (*p) {
+        case 'F': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_42;
+        }
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_43;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_40:
+    s_n_llhttp__internal__n_start_req_40: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_40;
+      }
+      switch (*p) {
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_41;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_39:
+    s_n_llhttp__internal__n_start_req_39: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_39;
+      }
+      switch (*p) {
+        case 'I': {
+          p++;
+          match = 34;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_40;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_45:
+    s_n_llhttp__internal__n_start_req_45: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_46;
+        return s_n_llhttp__internal__n_start_req_45;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob43, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 18;
+          match = 29;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_46;
+          return s_n_llhttp__internal__n_start_req_45;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_44:
+    s_n_llhttp__internal__n_start_req_44: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_44;
+      }
+      switch (*p) {
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_45;
+        }
+        case 'T': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_33:
+    s_n_llhttp__internal__n_start_req_33: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_33;
+      }
+      switch (*p) {
+        case 'A': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_34;
+        }
+        case 'L': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_37;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_38;
+        }
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_39;
+        }
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_44;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4514,19 +4727,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_48;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 32;
+          match = 17;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_48;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4539,40 +4752,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_49;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 15;
+          match = 44;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_49;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_47:
-    s_n_llhttp__internal__n_start_req_47: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_47;
-      }
-      switch (*p) {
-        case 'I': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_48;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_49;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4585,7 +4777,455 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_50;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 8);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 5);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 43;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_50;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_51:
+    s_n_llhttp__internal__n_start_req_51: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_51;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 20;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_51;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_47:
+    s_n_llhttp__internal__n_start_req_47: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_47;
+      }
+      switch (*p) {
+        case 'B': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_48;
+        }
+        case 'C': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_49;
+        }
+        case 'D': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_50;
+        }
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_51;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_46:
+    s_n_llhttp__internal__n_start_req_46: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_46;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_47;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_54:
+    s_n_llhttp__internal__n_start_req_54: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_54;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 14;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_54;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_56:
+    s_n_llhttp__internal__n_start_req_56: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_56;
+      }
+      switch (*p) {
+        case 'P': {
+          p++;
+          match = 37;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_57:
+    s_n_llhttp__internal__n_start_req_57: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_57;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 9);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 42;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_57;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_55:
+    s_n_llhttp__internal__n_start_req_55: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_55;
+      }
+      switch (*p) {
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_56;
+        }
+        case '_': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_57;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_53:
+    s_n_llhttp__internal__n_start_req_53: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_53;
+      }
+      switch (*p) {
+        case 'A': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_54;
+        }
+        case 'T': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_55;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_58:
+    s_n_llhttp__internal__n_start_req_58: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_58;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 33;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_58;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_59:
+    s_n_llhttp__internal__n_start_req_59: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_59;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob51, 7);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 26;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_59;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_52:
+    s_n_llhttp__internal__n_start_req_52: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_52;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_53;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_58;
+        }
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_59;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_61:
+    s_n_llhttp__internal__n_start_req_61: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_61;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob52, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 40;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_61;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_62:
+    s_n_llhttp__internal__n_start_req_62: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_62;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob53, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_62;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_60:
+    s_n_llhttp__internal__n_start_req_60: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_60;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_61;
+        }
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_62;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_65:
+    s_n_llhttp__internal__n_start_req_65: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_65;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob54, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 18;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_65;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_67:
+    s_n_llhttp__internal__n_start_req_67: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_67;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob55, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 32;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_67;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_68:
+    s_n_llhttp__internal__n_start_req_68: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_68;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob56, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 15;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_68;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_66:
+    s_n_llhttp__internal__n_start_req_66: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_66;
+      }
+      switch (*p) {
+        case 'I': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_67;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_68;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_70;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_69:
+    s_n_llhttp__internal__n_start_req_69: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_69;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob57, 8);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -4594,52 +5234,52 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_50;
+          return s_n_llhttp__internal__n_start_req_69;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_45:
-    s_n_llhttp__internal__n_start_req_45: {
+    case s_n_llhttp__internal__n_start_req_64:
+    s_n_llhttp__internal__n_start_req_64: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_45;
+        return s_n_llhttp__internal__n_start_req_64;
       }
       switch (*p) {
         case 'B': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_46;
+          goto s_n_llhttp__internal__n_start_req_65;
         }
         case 'L': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_47;
+          goto s_n_llhttp__internal__n_start_req_66;
         }
         case 'S': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_50;
+          goto s_n_llhttp__internal__n_start_req_69;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_44:
-    s_n_llhttp__internal__n_start_req_44: {
+    case s_n_llhttp__internal__n_start_req_63:
+    s_n_llhttp__internal__n_start_req_63: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_44;
+        return s_n_llhttp__internal__n_start_req_63;
       }
       switch (*p) {
         case 'N': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_45;
+          goto s_n_llhttp__internal__n_start_req_64;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
       }
       /* UNREACHABLE */;
@@ -4657,63 +5297,76 @@ static llparse_state_t llhttp__internal__run(
         }
         case 'B': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_2;
+          goto s_n_llhttp__internal__n_start_req_4;
         }
         case 'C': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_3;
+          goto s_n_llhttp__internal__n_start_req_5;
         }
         case 'D': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_8;
-        }
-        case 'G': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_9;
-        }
-        case 'H': {
-          p++;
           goto s_n_llhttp__internal__n_start_req_10;
         }
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_11;
-        }
-        case 'M': {
+        case 'F': {
           p++;
           goto s_n_llhttp__internal__n_start_req_14;
         }
+        case 'G': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_15;
+        }
+        case 'H': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_18;
+        }
+        case 'L': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_19;
+        }
+        case 'M': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_22;
+        }
         case 'N': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_23;
+          goto s_n_llhttp__internal__n_start_req_31;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_24;
+          goto s_n_llhttp__internal__n_start_req_32;
         }
         case 'P': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_25;
+          goto s_n_llhttp__internal__n_start_req_33;
         }
         case 'R': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_35;
+          goto s_n_llhttp__internal__n_start_req_46;
         }
         case 'S': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_39;
+          goto s_n_llhttp__internal__n_start_req_52;
         }
         case 'T': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_43;
+          goto s_n_llhttp__internal__n_start_req_60;
         }
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_44;
+          goto s_n_llhttp__internal__n_start_req_63;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_58;
+          goto s_n_llhttp__internal__n_error_70;
         }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_status_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_status_complete: {
+      switch (llhttp__on_status_complete(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_header_field_start;
       }
       /* UNREACHABLE */;
       abort();
@@ -4726,10 +5379,10 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_header_field_start;
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_61;
         }
       }
       /* UNREACHABLE */;
@@ -4774,7 +5427,7 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_header_field_start;
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
         }
         case 13: {
           p++;
@@ -4804,7 +5457,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_res_status_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_52;
+          goto s_n_llhttp__internal__n_error_62;
         }
       }
       /* UNREACHABLE */;
@@ -4884,7 +5537,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_update_status_code;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_53;
+          goto s_n_llhttp__internal__n_error_63;
         }
       }
       /* UNREACHABLE */;
@@ -4947,7 +5600,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_54;
+          goto s_n_llhttp__internal__n_error_66;
         }
       }
       /* UNREACHABLE */;
@@ -4964,7 +5617,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_res_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_55;
+          goto s_n_llhttp__internal__n_error_67;
         }
       }
       /* UNREACHABLE */;
@@ -5027,7 +5680,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_major_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_56;
+          goto s_n_llhttp__internal__n_error_68;
         }
       }
       /* UNREACHABLE */;
@@ -5040,7 +5693,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_res;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob58, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5051,7 +5704,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_res;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_59;
+          goto s_n_llhttp__internal__n_error_71;
         }
       }
       /* UNREACHABLE */;
@@ -5064,7 +5717,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_or_res_method_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob59, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5076,7 +5729,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_57;
+          goto s_n_llhttp__internal__n_error_69;
         }
       }
       /* UNREACHABLE */;
@@ -5089,7 +5742,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_or_res_method_3;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob60, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -5100,7 +5753,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_57;
+          goto s_n_llhttp__internal__n_error_69;
         }
       }
       /* UNREACHABLE */;
@@ -5121,7 +5774,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_57;
+          goto s_n_llhttp__internal__n_error_69;
         }
       }
       /* UNREACHABLE */;
@@ -5138,7 +5791,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_57;
+          goto s_n_llhttp__internal__n_error_69;
         }
       }
       /* UNREACHABLE */;
@@ -5207,7 +5860,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_45: {
+  s_n_llhttp__internal__n_error_53: {
     state->error = 0x7;
     state->reason = "Invalid characters in url";
     state->error_pos = (const char*) p;
@@ -5233,10 +5886,20 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_update_finish_2;
+      default:
+        goto s_n_llhttp__internal__n_closed;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_invoke_update_finish_1: {
     switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_closed;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags;
     }
     /* UNREACHABLE */;
     abort();
@@ -5268,7 +5931,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_18: {
+  s_n_llhttp__internal__n_error_17: {
     state->error = 0x14;
     state->reason = "`on_chunk_complete` callback error";
     state->error_pos = (const char*) p;
@@ -5284,7 +5947,7 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause_7;
       default:
-        goto s_n_llhttp__internal__n_error_18;
+        goto s_n_llhttp__internal__n_error_17;
     }
     /* UNREACHABLE */;
     abort();
@@ -5292,15 +5955,6 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_error_16: {
     state->error = 0x4;
     state->reason = "Content-Length can't be present with Transfer-Encoding";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_17: {
-    state->error = 0x4;
-    state->reason = "Content-Length can't be present with chunked encoding";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -5446,6 +6100,24 @@ static llparse_state_t llhttp__internal__run(
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_parameters: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_parameters(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_chunk_size_almost_done;
     /* UNREACHABLE */;
     abort();
   }
@@ -5616,22 +6288,10 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_3: {
-    switch (llhttp__internal__c_test_flags_3(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_error_17;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_2: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_1: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_error_16;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_flags_3;
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
     }
@@ -5641,7 +6301,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_test_flags_1: {
     switch (llhttp__internal__c_test_flags_1(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_flags_2;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_1;
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
     }
@@ -5658,7 +6318,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_19: {
+  s_n_llhttp__internal__n_error_18: {
     state->error = 0x2;
     state->reason = "Expected LF after headers";
     state->error_pos = (const char*) p;
@@ -5677,20 +6337,39 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_20;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_19;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_20;
+    goto s_n_llhttp__internal__n_error_19;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_4: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_2: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_field_colon_discard_ws;
       default:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_21: {
+    state->error = 0xa;
+    state->reason = "Invalid header value char";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_4: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_discard_ws;
+      default:
+        goto s_n_llhttp__internal__n_error_21;
     }
     /* UNREACHABLE */;
     abort();
@@ -5714,10 +6393,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_field_start;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_header_field_start;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     /* UNREACHABLE */;
     abort();
   }
@@ -5787,7 +6466,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_21: {
+  s_n_llhttp__internal__n_error_20: {
     state->error = 0xa;
     state->reason = "Invalid header value char";
     state->error_pos = (const char*) p;
@@ -5796,12 +6475,12 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_5: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_3: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_discard_lws;
       default:
-        goto s_n_llhttp__internal__n_error_21;
+        goto s_n_llhttp__internal__n_error_20;
     }
     /* UNREACHABLE */;
     abort();
@@ -5812,6 +6491,16 @@ static llparse_state_t llhttp__internal__run(
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_5: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_discard_lws;
+      default:
+        goto s_n_llhttp__internal__n_error_23;
+    }
     /* UNREACHABLE */;
     abort();
   }
@@ -5836,7 +6525,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_update_header_state_2: {
     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     }
     /* UNREACHABLE */;
     abort();
@@ -5868,7 +6557,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_10: {
     switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     }
     /* UNREACHABLE */;
     abort();
@@ -5884,7 +6573,7 @@ static llparse_state_t llhttp__internal__run(
       case 8:
         goto s_n_llhttp__internal__n_invoke_or_flags_10;
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     }
     /* UNREACHABLE */;
     abort();
@@ -5968,8 +6657,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_6: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_6: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_lenient;
       default:
@@ -6127,8 +6816,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_7: {
-    switch (llhttp__internal__c_test_flags_7(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_flags_2: {
+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_header_value_content_length;
       default:
@@ -6181,8 +6870,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_9: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_7: {
+    switch (llhttp__internal__c_test_lenient_flags_7(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
       default:
@@ -6194,7 +6883,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_type_1: {
     switch (llhttp__internal__c_load_type(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_flags_9;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
       default:
         goto s_n_llhttp__internal__n_header_value_te_chunked;
     }
@@ -6225,8 +6914,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_10: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_8: {
+    switch (llhttp__internal__c_test_lenient_flags_7(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
       default:
@@ -6238,7 +6927,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_type_2: {
     switch (llhttp__internal__c_load_type(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_flags_10;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_8;
       default:
         goto s_n_llhttp__internal__n_invoke_or_flags_17;
     }
@@ -6253,8 +6942,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_8: {
-    switch (llhttp__internal__c_test_flags_8(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_flags_3: {
+    switch (llhttp__internal__c_test_flags_3(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_invoke_load_type_2;
       default:
@@ -6276,9 +6965,9 @@ static llparse_state_t llhttp__internal__run(
       case 1:
         goto s_n_llhttp__internal__n_header_value_connection;
       case 2:
-        goto s_n_llhttp__internal__n_invoke_test_flags_7;
+        goto s_n_llhttp__internal__n_invoke_test_flags_2;
       case 3:
-        goto s_n_llhttp__internal__n_invoke_test_flags_8;
+        goto s_n_llhttp__internal__n_invoke_test_flags_3;
       case 4:
         goto s_n_llhttp__internal__n_invoke_or_flags_18;
       default:
@@ -6297,11 +6986,11 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_header_value_discard_ws;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
     /* UNREACHABLE */;
     abort();
   }
@@ -6315,11 +7004,11 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_header_value_discard_ws;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
     /* UNREACHABLE */;
     abort();
   }
@@ -6356,10 +7045,18 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_invoke_llhttp__on_url_complete: {
+    switch (llhttp__on_url_complete(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_invoke_update_http_minor: {
     switch (llhttp__internal__c_update_http_minor(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete;
     }
     /* UNREACHABLE */;
     abort();
@@ -6415,7 +7112,25 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_33: {
+  s_n_llhttp__internal__n_error_37: {
+    state->error = 0x17;
+    state->reason = "Pause on PRI/Upgrade";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_38: {
+    state->error = 0x9;
+    state->reason = "Expected HTTP/2 Connection Preface";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_36: {
     state->error = 0x9;
     state->reason = "Expected CRLF after version";
     state->error_pos = (const char*) p;
@@ -6424,15 +7139,117 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_store_http_minor: {
-    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
+  s_n_llhttp__internal__n_invoke_load_method_1: {
+    switch (llhttp__internal__c_load_method(state, p, endp)) {
+      case 34:
+        goto s_n_llhttp__internal__n_req_pri_upgrade;
       default:
-        goto s_n_llhttp__internal__n_req_http_end;
+        goto s_n_llhttp__internal__n_req_http_complete;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_35: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 9:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      default:
+        goto s_n_llhttp__internal__n_error_35;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_39: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_1: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      default:
+        goto s_n_llhttp__internal__n_error_39;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_40: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_2: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      default:
+        goto s_n_llhttp__internal__n_error_40;
     }
     /* UNREACHABLE */;
     abort();
   }
   s_n_llhttp__internal__n_error_34: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_major: {
+    switch (llhttp__internal__c_load_http_major(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_1;
+      case 2:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_2;
+      default:
+        goto s_n_llhttp__internal__n_error_34;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_9: {
+    switch (llhttp__internal__c_test_lenient_flags_9(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      default:
+        goto s_n_llhttp__internal__n_invoke_load_http_major;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_http_minor: {
+    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_9;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_41: {
     state->error = 0x9;
     state->reason = "Invalid minor version";
     state->error_pos = (const char*) p;
@@ -6441,7 +7258,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_35: {
+  s_n_llhttp__internal__n_error_42: {
     state->error = 0x9;
     state->reason = "Expected dot";
     state->error_pos = (const char*) p;
@@ -6458,7 +7275,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_36: {
+  s_n_llhttp__internal__n_error_43: {
     state->error = 0x9;
     state->reason = "Invalid major version";
     state->error_pos = (const char*) p;
@@ -6467,7 +7284,94 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_38: {
+  s_n_llhttp__internal__n_error_33: {
+    state->error = 0x8;
+    state->reason = "Invalid method for HTTP/x.x request";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_method: {
+    switch (llhttp__internal__c_load_method(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 1:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 2:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 3:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 4:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 5:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 6:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 7:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 8:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 9:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 10:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 11:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 12:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 13:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 14:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 15:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 16:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 17:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 18:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 19:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 20:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 21:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 22:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 23:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 24:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 25:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 26:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 27:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 28:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 29:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 30:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 31:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 32:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 33:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 34:
+        goto s_n_llhttp__internal__n_req_http_major;
+      default:
+        goto s_n_llhttp__internal__n_error_33;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_46: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -6476,7 +7380,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_37: {
+  s_n_llhttp__internal__n_error_44: {
     state->error = 0x8;
     state->reason = "Expected SOURCE method for ICE/x.x request";
     state->error_pos = (const char*) p;
@@ -6485,12 +7389,65 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_is_equal_method_1: {
-    switch (llhttp__internal__c_is_equal_method_1(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_error_37;
-      default:
+  s_n_llhttp__internal__n_invoke_load_method_2: {
+    switch (llhttp__internal__c_load_method(state, p, endp)) {
+      case 33:
         goto s_n_llhttp__internal__n_req_http_major;
+      default:
+        goto s_n_llhttp__internal__n_error_44;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_45: {
+    state->error = 0x8;
+    state->reason = "Invalid method for RTSP/x.x request";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_method_3: {
+    switch (llhttp__internal__c_load_method(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 3:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 6:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 35:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 36:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 37:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 38:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 39:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 40:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 41:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 42:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 43:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 44:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 45:
+        goto s_n_llhttp__internal__n_req_http_major;
+      default:
+        goto s_n_llhttp__internal__n_error_45;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1: {
+    switch (llhttp__on_url_complete(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_req_http_start;
     }
     /* UNREACHABLE */;
     abort();
@@ -6563,7 +7520,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_39: {
+  s_n_llhttp__internal__n_error_47: {
     state->error = 0x7;
     state->reason = "Invalid char in url fragment start";
     state->error_pos = (const char*) p;
@@ -6623,7 +7580,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_40: {
+  s_n_llhttp__internal__n_error_48: {
     state->error = 0x7;
     state->reason = "Invalid char in url query";
     state->error_pos = (const char*) p;
@@ -6632,7 +7589,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_41: {
+  s_n_llhttp__internal__n_error_49: {
     state->error = 0x7;
     state->reason = "Invalid char in url path";
     state->error_pos = (const char*) p;
@@ -6743,7 +7700,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_42: {
+  s_n_llhttp__internal__n_error_50: {
     state->error = 0x7;
     state->reason = "Double @ in url";
     state->error_pos = (const char*) p;
@@ -6752,7 +7709,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_43: {
+  s_n_llhttp__internal__n_error_51: {
     state->error = 0x7;
     state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
@@ -6761,7 +7718,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_44: {
+  s_n_llhttp__internal__n_error_52: {
     state->error = 0x7;
     state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
@@ -6770,7 +7727,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_46: {
+  s_n_llhttp__internal__n_error_54: {
     state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
@@ -6779,7 +7736,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_47: {
+  s_n_llhttp__internal__n_error_55: {
     state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
@@ -6788,7 +7745,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_48: {
+  s_n_llhttp__internal__n_error_56: {
     state->error = 0x7;
     state->reason = "Unexpected start char in url";
     state->error_pos = (const char*) p;
@@ -6807,7 +7764,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_49: {
+  s_n_llhttp__internal__n_error_57: {
     state->error = 0x6;
     state->reason = "Expected space after method";
     state->error_pos = (const char*) p;
@@ -6824,7 +7781,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_58: {
+  s_n_llhttp__internal__n_error_70: {
     state->error = 0x6;
     state->reason = "Invalid method encountered";
     state->error_pos = (const char*) p;
@@ -6833,7 +7790,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_50: {
+  s_n_llhttp__internal__n_error_60: {
     state->error = 0xd;
     state->reason = "Response overflow";
     state->error_pos = (const char*) p;
@@ -6845,14 +7802,14 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_mul_add_status_code: {
     switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
       case 1:
-        goto s_n_llhttp__internal__n_error_50;
+        goto s_n_llhttp__internal__n_error_60;
       default:
         goto s_n_llhttp__internal__n_res_status_code;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_51: {
+  s_n_llhttp__internal__n_error_61: {
     state->error = 0x2;
     state->reason = "Expected LF after CR";
     state->error_pos = (const char*) p;
@@ -6871,11 +7828,11 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_field_start;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_header_field_start;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
     /* UNREACHABLE */;
     abort();
   }
@@ -6897,7 +7854,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_52: {
+  s_n_llhttp__internal__n_error_62: {
     state->error = 0xd;
     state->reason = "Invalid response status";
     state->error_pos = (const char*) p;
@@ -6914,7 +7871,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_53: {
+  s_n_llhttp__internal__n_error_63: {
     state->error = 0x9;
     state->reason = "Expected space after version";
     state->error_pos = (const char*) p;
@@ -6923,15 +7880,107 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_store_http_minor_1: {
-    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
-      default:
+  s_n_llhttp__internal__n_error_59: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_3: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 9:
         goto s_n_llhttp__internal__n_res_http_end;
+      default:
+        goto s_n_llhttp__internal__n_error_59;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_54: {
+  s_n_llhttp__internal__n_error_64: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_4: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_res_http_end;
+      case 1:
+        goto s_n_llhttp__internal__n_res_http_end;
+      default:
+        goto s_n_llhttp__internal__n_error_64;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_65: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_5: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_res_http_end;
+      default:
+        goto s_n_llhttp__internal__n_error_65;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_58: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_major_1: {
+    switch (llhttp__internal__c_load_http_major(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_3;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_4;
+      case 2:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_5;
+      default:
+        goto s_n_llhttp__internal__n_error_58;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_10: {
+    switch (llhttp__internal__c_test_lenient_flags_9(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_res_http_end;
+      default:
+        goto s_n_llhttp__internal__n_invoke_load_http_major_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_http_minor_1: {
+    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_10;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_66: {
     state->error = 0x9;
     state->reason = "Invalid minor version";
     state->error_pos = (const char*) p;
@@ -6940,7 +7989,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_55: {
+  s_n_llhttp__internal__n_error_67: {
     state->error = 0x9;
     state->reason = "Expected dot";
     state->error_pos = (const char*) p;
@@ -6957,7 +8006,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_56: {
+  s_n_llhttp__internal__n_error_68: {
     state->error = 0x9;
     state->reason = "Invalid major version";
     state->error_pos = (const char*) p;
@@ -6966,7 +8015,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_59: {
+  s_n_llhttp__internal__n_error_71: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -6991,7 +8040,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_57: {
+  s_n_llhttp__internal__n_error_69: {
     state->error = 0x8;
     state->reason = "Invalid word encountered";
     state->error_pos = (const char*) p;
@@ -7115,171 +8164,204 @@ int llhttp__internal_execute(llhttp__internal_t* state, const char* p, const cha
 typedef int (*llhttp__internal__span_cb)(
              llhttp__internal_t*, const char*, const char*);
 
-static const unsigned char llparse_blob0[] = {
-  'C', 'L'
-};
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob1[] = {
+static const unsigned char ALIGN(16) llparse_blob0[] = {
   0x9, 0x9, 0xc, 0xc, '!', '"', '$', '>', '@', '~', 0x80,
   0xff, 0x0, 0x0, 0x0, 0x0
 };
 #endif  /* __SSE4_2__ */
-static const unsigned char llparse_blob2[] = {
+static const unsigned char llparse_blob1[] = {
   'o', 'n'
 };
-static const unsigned char llparse_blob3[] = {
+static const unsigned char llparse_blob2[] = {
   'e', 'c', 't', 'i', 'o', 'n'
 };
-static const unsigned char llparse_blob4[] = {
+static const unsigned char llparse_blob3[] = {
   'l', 'o', 's', 'e'
 };
-static const unsigned char llparse_blob5[] = {
+static const unsigned char llparse_blob4[] = {
   'e', 'e', 'p', '-', 'a', 'l', 'i', 'v', 'e'
 };
-static const unsigned char llparse_blob6[] = {
+static const unsigned char llparse_blob5[] = {
   'p', 'g', 'r', 'a', 'd', 'e'
 };
-static const unsigned char llparse_blob7[] = {
+static const unsigned char llparse_blob6[] = {
   'c', 'h', 'u', 'n', 'k', 'e', 'd'
 };
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob8[] = {
+static const unsigned char ALIGN(16) llparse_blob7[] = {
   0x9, 0x9, ' ', '~', 0x80, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0,
   0x0, 0x0, 0x0, 0x0, 0x0
 };
 #endif  /* __SSE4_2__ */
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob9[] = {
+static const unsigned char ALIGN(16) llparse_blob8[] = {
   ' ', '!', '#', '\'', '*', '+', '-', '.', '0', '9', 'A',
   'Z', '^', 'z', '|', '|'
 };
 #endif  /* __SSE4_2__ */
 #ifdef __SSE4_2__
-static const unsigned char ALIGN(16) llparse_blob10[] = {
+static const unsigned char ALIGN(16) llparse_blob9[] = {
   '~', '~', 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
   0x0, 0x0, 0x0, 0x0, 0x0
 };
 #endif  /* __SSE4_2__ */
-static const unsigned char llparse_blob11[] = {
+static const unsigned char llparse_blob10[] = {
   'e', 'n', 't', '-', 'l', 'e', 'n', 'g', 't', 'h'
 };
-static const unsigned char llparse_blob12[] = {
+static const unsigned char llparse_blob11[] = {
   'r', 'o', 'x', 'y', '-', 'c', 'o', 'n', 'n', 'e', 'c',
   't', 'i', 'o', 'n'
 };
-static const unsigned char llparse_blob13[] = {
+static const unsigned char llparse_blob12[] = {
   'r', 'a', 'n', 's', 'f', 'e', 'r', '-', 'e', 'n', 'c',
   'o', 'd', 'i', 'n', 'g'
 };
-static const unsigned char llparse_blob14[] = {
+static const unsigned char llparse_blob13[] = {
   'p', 'g', 'r', 'a', 'd', 'e'
 };
-static const unsigned char llparse_blob15[] = {
+static const unsigned char llparse_blob14[] = {
   0xd, 0xa
 };
-static const unsigned char llparse_blob16[] = {
+static const unsigned char llparse_blob15[] = {
   'T', 'T', 'P', '/'
+};
+static const unsigned char llparse_blob16[] = {
+  0xd, 0xa, 0xd, 0xa, 'S', 'M', 0xd, 0xa, 0xd, 0xa
 };
 static const unsigned char llparse_blob17[] = {
   'C', 'E', '/'
 };
 static const unsigned char llparse_blob18[] = {
-  'I', 'N', 'D'
+  'T', 'S', 'P', '/'
 };
 static const unsigned char llparse_blob19[] = {
-  'E', 'C', 'K', 'O', 'U', 'T'
+  'N', 'O', 'U', 'N', 'C', 'E'
 };
 static const unsigned char llparse_blob20[] = {
-  'N', 'E', 'C', 'T'
+  'I', 'N', 'D'
 };
 static const unsigned char llparse_blob21[] = {
-  'E', 'L', 'E', 'T', 'E'
+  'E', 'C', 'K', 'O', 'U', 'T'
 };
 static const unsigned char llparse_blob22[] = {
-  'E', 'T'
+  'N', 'E', 'C', 'T'
 };
 static const unsigned char llparse_blob23[] = {
-  'E', 'A', 'D'
+  'E', 'T', 'E'
 };
 static const unsigned char llparse_blob24[] = {
-  'N', 'K'
+  'C', 'R', 'I', 'B', 'E'
 };
 static const unsigned char llparse_blob25[] = {
-  'C', 'K'
+  'L', 'U', 'S', 'H'
 };
 static const unsigned char llparse_blob26[] = {
-  'S', 'E', 'A', 'R', 'C', 'H'
+  'E', 'T'
 };
 static const unsigned char llparse_blob27[] = {
-  'R', 'G', 'E'
+  'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
 };
 static const unsigned char llparse_blob28[] = {
-  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
+  'E', 'A', 'D'
 };
 static const unsigned char llparse_blob29[] = {
-  'L', 'E', 'N', 'D', 'A', 'R'
-};
-static const unsigned char llparse_blob30[] = {
-  'V', 'E'
-};
-static const unsigned char llparse_blob31[] = {
-  'O', 'T', 'I', 'F', 'Y'
-};
-static const unsigned char llparse_blob32[] = {
-  'P', 'T', 'I', 'O', 'N', 'S'
-};
-static const unsigned char llparse_blob33[] = {
-  'T', 'C', 'H'
-};
-static const unsigned char llparse_blob34[] = {
-  'S', 'T'
-};
-static const unsigned char llparse_blob35[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob36[] = {
-  'A', 'T', 'C', 'H'
-};
-static const unsigned char llparse_blob37[] = {
-  'G', 'E'
-};
-static const unsigned char llparse_blob38[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob39[] = {
-  'O', 'R', 'T'
-};
-static const unsigned char llparse_blob40[] = {
-  'A', 'R', 'C', 'H'
-};
-static const unsigned char llparse_blob41[] = {
-  'U', 'R', 'C', 'E'
-};
-static const unsigned char llparse_blob42[] = {
-  'B', 'S', 'C', 'R', 'I', 'B', 'E'
-};
-static const unsigned char llparse_blob43[] = {
-  'R', 'A', 'C', 'E'
-};
-static const unsigned char llparse_blob44[] = {
-  'I', 'N', 'D'
-};
-static const unsigned char llparse_blob45[] = {
   'N', 'K'
 };
-static const unsigned char llparse_blob46[] = {
+static const unsigned char llparse_blob30[] = {
   'C', 'K'
 };
+static const unsigned char llparse_blob31[] = {
+  'S', 'E', 'A', 'R', 'C', 'H'
+};
+static const unsigned char llparse_blob32[] = {
+  'R', 'G', 'E'
+};
+static const unsigned char llparse_blob33[] = {
+  'C', 'T', 'I', 'V', 'I', 'T', 'Y'
+};
+static const unsigned char llparse_blob34[] = {
+  'L', 'E', 'N', 'D', 'A', 'R'
+};
+static const unsigned char llparse_blob35[] = {
+  'V', 'E'
+};
+static const unsigned char llparse_blob36[] = {
+  'O', 'T', 'I', 'F', 'Y'
+};
+static const unsigned char llparse_blob37[] = {
+  'P', 'T', 'I', 'O', 'N', 'S'
+};
+static const unsigned char llparse_blob38[] = {
+  'C', 'H'
+};
+static const unsigned char llparse_blob39[] = {
+  'S', 'E'
+};
+static const unsigned char llparse_blob40[] = {
+  'A', 'Y'
+};
+static const unsigned char llparse_blob41[] = {
+  'S', 'T'
+};
+static const unsigned char llparse_blob42[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob43[] = {
+  'A', 'T', 'C', 'H'
+};
+static const unsigned char llparse_blob44[] = {
+  'G', 'E'
+};
+static const unsigned char llparse_blob45[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob46[] = {
+  'O', 'R', 'D'
+};
 static const unsigned char llparse_blob47[] = {
-  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
+  'I', 'R', 'E', 'C', 'T'
 };
 static const unsigned char llparse_blob48[] = {
-  'H', 'T', 'T', 'P', '/'
+  'O', 'R', 'T'
 };
 static const unsigned char llparse_blob49[] = {
-  'A', 'D'
+  'R', 'C', 'H'
 };
 static const unsigned char llparse_blob50[] = {
+  'P', 'A', 'R', 'A', 'M', 'E', 'T', 'E', 'R'
+};
+static const unsigned char llparse_blob51[] = {
+  'U', 'R', 'C', 'E'
+};
+static const unsigned char llparse_blob52[] = {
+  'B', 'S', 'C', 'R', 'I', 'B', 'E'
+};
+static const unsigned char llparse_blob53[] = {
+  'A', 'R', 'D', 'O', 'W', 'N'
+};
+static const unsigned char llparse_blob54[] = {
+  'A', 'C', 'E'
+};
+static const unsigned char llparse_blob55[] = {
+  'I', 'N', 'D'
+};
+static const unsigned char llparse_blob56[] = {
+  'N', 'K'
+};
+static const unsigned char llparse_blob57[] = {
+  'C', 'K'
+};
+static const unsigned char llparse_blob58[] = {
+  'U', 'B', 'S', 'C', 'R', 'I', 'B', 'E'
+};
+static const unsigned char llparse_blob59[] = {
+  'H', 'T', 'T', 'P', '/'
+};
+static const unsigned char llparse_blob60[] = {
+  'A', 'D'
+};
+static const unsigned char llparse_blob61[] = {
   'T', 'P', '/'
 };
 
@@ -7295,38 +8377,6 @@ struct llparse_match_s {
   const unsigned char* current;
 };
 typedef struct llparse_match_s llparse_match_t;
-
-static llparse_match_t llparse__match_sequence_id(
-    llhttp__internal_t* s, const unsigned char* p,
-    const unsigned char* endp,
-    const unsigned char* seq, uint32_t seq_len) {
-  uint32_t index;
-  llparse_match_t res;
-
-  index = s->_index;
-  for (; p != endp; p++) {
-    unsigned char current;
-
-    current = *p;
-    if (current == seq[index]) {
-      if (++index == seq_len) {
-        res.status = kMatchComplete;
-        goto reset;
-      }
-    } else {
-      res.status = kMatchMismatch;
-      goto reset;
-    }
-  }
-  s->_index = index;
-  res.status = kMatchPause;
-  res.current = p;
-  return res;
-reset:
-  s->_index = 0;
-  res.current = p;
-  return res;
-}
 
 static llparse_match_t llparse__match_sequence_to_lower(
     llhttp__internal_t* s, const unsigned char* p,
@@ -7392,8 +8442,41 @@ reset:
   return res;
 }
 
+static llparse_match_t llparse__match_sequence_id(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp,
+    const unsigned char* seq, uint32_t seq_len) {
+  uint32_t index;
+  llparse_match_t res;
+
+  index = s->_index;
+  for (; p != endp; p++) {
+    unsigned char current;
+
+    current = *p;
+    if (current == seq[index]) {
+      if (++index == seq_len) {
+        res.status = kMatchComplete;
+        goto reset;
+      }
+    } else {
+      res.status = kMatchMismatch;
+      goto reset;
+    }
+  }
+  s->_index = index;
+  res.status = kMatchPause;
+  res.current = p;
+  return res;
+reset:
+  s->_index = 0;
+  res.current = p;
+  return res;
+}
+
 enum llparse_state_e {
   s_error,
+  s_n_llhttp__internal__n_closed,
   s_n_llhttp__internal__n_invoke_llhttp__after_message_complete,
   s_n_llhttp__internal__n_pause_1,
   s_n_llhttp__internal__n_invoke_is_equal_upgrade,
@@ -7405,6 +8488,8 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_invoke_is_equal_content_length,
   s_n_llhttp__internal__n_chunk_size_almost_done,
   s_n_llhttp__internal__n_chunk_parameters,
+  s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters,
+  s_n_llhttp__internal__n_chunk_parameters_ows,
   s_n_llhttp__internal__n_chunk_size_otherwise,
   s_n_llhttp__internal__n_chunk_size,
   s_n_llhttp__internal__n_chunk_size_digit,
@@ -7416,14 +8501,15 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_invoke_llhttp__after_headers_complete,
   s_n_llhttp__internal__n_headers_almost_done,
   s_n_llhttp__internal__n_header_field_colon_discard_ws,
-  s_n_llhttp__internal__n_error_15,
+  s_n_llhttp__internal__n_error_14,
+  s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_value,
   s_n_llhttp__internal__n_header_value_discard_lws,
   s_n_llhttp__internal__n_header_value_discard_ws_almost_done,
   s_n_llhttp__internal__n_header_value_lws,
   s_n_llhttp__internal__n_header_value_almost_done,
   s_n_llhttp__internal__n_header_value_lenient,
-  s_n_llhttp__internal__n_error_19,
+  s_n_llhttp__internal__n_error_20,
   s_n_llhttp__internal__n_header_value_otherwise,
   s_n_llhttp__internal__n_header_value_connection_token,
   s_n_llhttp__internal__n_header_value_connection_ws,
@@ -7431,12 +8517,12 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_connection_2,
   s_n_llhttp__internal__n_header_value_connection_3,
   s_n_llhttp__internal__n_header_value_connection,
-  s_n_llhttp__internal__n_error_21,
   s_n_llhttp__internal__n_error_22,
+  s_n_llhttp__internal__n_error_23,
   s_n_llhttp__internal__n_header_value_content_length_ws,
   s_n_llhttp__internal__n_header_value_content_length,
+  s_n_llhttp__internal__n_error_25,
   s_n_llhttp__internal__n_error_24,
-  s_n_llhttp__internal__n_error_23,
   s_n_llhttp__internal__n_header_value_te_token_ows,
   s_n_llhttp__internal__n_header_value,
   s_n_llhttp__internal__n_header_value_te_token,
@@ -7444,6 +8530,7 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_value_te_chunked,
   s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
   s_n_llhttp__internal__n_header_value_discard_ws,
+  s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete,
   s_n_llhttp__internal__n_header_field_general_otherwise,
   s_n_llhttp__internal__n_header_field_general,
   s_n_llhttp__internal__n_header_field_colon,
@@ -7459,13 +8546,15 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_header_field_start,
   s_n_llhttp__internal__n_url_skip_to_http09,
   s_n_llhttp__internal__n_url_skip_lf_to_http09,
-  s_n_llhttp__internal__n_req_http_end_1,
-  s_n_llhttp__internal__n_req_http_end,
+  s_n_llhttp__internal__n_req_pri_upgrade,
+  s_n_llhttp__internal__n_req_http_complete_1,
+  s_n_llhttp__internal__n_req_http_complete,
   s_n_llhttp__internal__n_req_http_minor,
   s_n_llhttp__internal__n_req_http_dot,
   s_n_llhttp__internal__n_req_http_major,
   s_n_llhttp__internal__n_req_http_start_1,
   s_n_llhttp__internal__n_req_http_start_2,
+  s_n_llhttp__internal__n_req_http_start_3,
   s_n_llhttp__internal__n_req_http_start,
   s_n_llhttp__internal__n_url_skip_to_http,
   s_n_llhttp__internal__n_url_fragment,
@@ -7487,57 +8576,77 @@ enum llparse_state_e {
   s_n_llhttp__internal__n_span_start_llhttp__on_url,
   s_n_llhttp__internal__n_req_spaces_before_url,
   s_n_llhttp__internal__n_req_first_space_before_url,
-  s_n_llhttp__internal__n_start_req_1,
   s_n_llhttp__internal__n_start_req_2,
+  s_n_llhttp__internal__n_start_req_3,
+  s_n_llhttp__internal__n_start_req_1,
   s_n_llhttp__internal__n_start_req_4,
   s_n_llhttp__internal__n_start_req_6,
-  s_n_llhttp__internal__n_start_req_7,
-  s_n_llhttp__internal__n_start_req_5,
-  s_n_llhttp__internal__n_start_req_3,
   s_n_llhttp__internal__n_start_req_8,
   s_n_llhttp__internal__n_start_req_9,
-  s_n_llhttp__internal__n_start_req_10,
+  s_n_llhttp__internal__n_start_req_7,
+  s_n_llhttp__internal__n_start_req_5,
   s_n_llhttp__internal__n_start_req_12,
   s_n_llhttp__internal__n_start_req_13,
   s_n_llhttp__internal__n_start_req_11,
-  s_n_llhttp__internal__n_start_req_15,
+  s_n_llhttp__internal__n_start_req_10,
+  s_n_llhttp__internal__n_start_req_14,
+  s_n_llhttp__internal__n_start_req_17,
   s_n_llhttp__internal__n_start_req_16,
+  s_n_llhttp__internal__n_start_req_15,
   s_n_llhttp__internal__n_start_req_18,
   s_n_llhttp__internal__n_start_req_20,
   s_n_llhttp__internal__n_start_req_21,
   s_n_llhttp__internal__n_start_req_19,
-  s_n_llhttp__internal__n_start_req_17,
-  s_n_llhttp__internal__n_start_req_22,
-  s_n_llhttp__internal__n_start_req_14,
   s_n_llhttp__internal__n_start_req_23,
   s_n_llhttp__internal__n_start_req_24,
   s_n_llhttp__internal__n_start_req_26,
+  s_n_llhttp__internal__n_start_req_28,
+  s_n_llhttp__internal__n_start_req_29,
   s_n_llhttp__internal__n_start_req_27,
+  s_n_llhttp__internal__n_start_req_25,
+  s_n_llhttp__internal__n_start_req_30,
+  s_n_llhttp__internal__n_start_req_22,
   s_n_llhttp__internal__n_start_req_31,
   s_n_llhttp__internal__n_start_req_32,
-  s_n_llhttp__internal__n_start_req_30,
-  s_n_llhttp__internal__n_start_req_29,
-  s_n_llhttp__internal__n_start_req_28,
+  s_n_llhttp__internal__n_start_req_35,
+  s_n_llhttp__internal__n_start_req_36,
   s_n_llhttp__internal__n_start_req_34,
-  s_n_llhttp__internal__n_start_req_33,
-  s_n_llhttp__internal__n_start_req_25,
   s_n_llhttp__internal__n_start_req_37,
   s_n_llhttp__internal__n_start_req_38,
-  s_n_llhttp__internal__n_start_req_36,
-  s_n_llhttp__internal__n_start_req_35,
-  s_n_llhttp__internal__n_start_req_40,
-  s_n_llhttp__internal__n_start_req_41,
   s_n_llhttp__internal__n_start_req_42,
-  s_n_llhttp__internal__n_start_req_39,
   s_n_llhttp__internal__n_start_req_43,
-  s_n_llhttp__internal__n_start_req_46,
-  s_n_llhttp__internal__n_start_req_48,
-  s_n_llhttp__internal__n_start_req_49,
-  s_n_llhttp__internal__n_start_req_47,
-  s_n_llhttp__internal__n_start_req_50,
+  s_n_llhttp__internal__n_start_req_41,
+  s_n_llhttp__internal__n_start_req_40,
+  s_n_llhttp__internal__n_start_req_39,
   s_n_llhttp__internal__n_start_req_45,
   s_n_llhttp__internal__n_start_req_44,
+  s_n_llhttp__internal__n_start_req_33,
+  s_n_llhttp__internal__n_start_req_48,
+  s_n_llhttp__internal__n_start_req_49,
+  s_n_llhttp__internal__n_start_req_50,
+  s_n_llhttp__internal__n_start_req_51,
+  s_n_llhttp__internal__n_start_req_47,
+  s_n_llhttp__internal__n_start_req_46,
+  s_n_llhttp__internal__n_start_req_54,
+  s_n_llhttp__internal__n_start_req_56,
+  s_n_llhttp__internal__n_start_req_57,
+  s_n_llhttp__internal__n_start_req_55,
+  s_n_llhttp__internal__n_start_req_53,
+  s_n_llhttp__internal__n_start_req_58,
+  s_n_llhttp__internal__n_start_req_59,
+  s_n_llhttp__internal__n_start_req_52,
+  s_n_llhttp__internal__n_start_req_61,
+  s_n_llhttp__internal__n_start_req_62,
+  s_n_llhttp__internal__n_start_req_60,
+  s_n_llhttp__internal__n_start_req_65,
+  s_n_llhttp__internal__n_start_req_67,
+  s_n_llhttp__internal__n_start_req_68,
+  s_n_llhttp__internal__n_start_req_66,
+  s_n_llhttp__internal__n_start_req_69,
+  s_n_llhttp__internal__n_start_req_64,
+  s_n_llhttp__internal__n_start_req_63,
   s_n_llhttp__internal__n_start_req,
+  s_n_llhttp__internal__n_invoke_llhttp__on_status_complete,
   s_n_llhttp__internal__n_res_line_almost_done,
   s_n_llhttp__internal__n_res_status,
   s_n_llhttp__internal__n_span_start_llhttp__on_status,
@@ -7572,6 +8681,10 @@ int llhttp__on_header_value(
     const unsigned char* endp);
 
 int llhttp__on_body(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
+int llhttp__on_chunk_parameters(
     llhttp__internal_t* s, const unsigned char* p,
     const unsigned char* endp);
 
@@ -7630,6 +8743,10 @@ int llhttp__internal__c_update_http_minor(
   return 0;
 }
 
+int llhttp__on_url_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
 int llhttp__internal__c_test_flags(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -7664,6 +8781,13 @@ int llhttp__internal__c_update_finish_1(
   return 0;
 }
 
+int llhttp__internal__c_test_lenient_flags(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 4) == 4;
+}
+
 int llhttp__internal__c_test_flags_1(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -7671,18 +8795,11 @@ int llhttp__internal__c_test_flags_1(
   return (state->flags & 544) == 544;
 }
 
-int llhttp__internal__c_test_flags_2(
+int llhttp__internal__c_test_lenient_flags_1(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
-  return (state->flags & 256) == 256;
-}
-
-int llhttp__internal__c_test_flags_3(
-    llhttp__internal_t* state,
-    const unsigned char* p,
-    const unsigned char* endp) {
-  return (state->flags & 40) == 40;
+  return (state->lenient_flags & 2) == 2;
 }
 
 int llhttp__before_headers_complete(
@@ -7750,7 +8867,7 @@ int llhttp__internal__c_or_flags(
   return 0;
 }
 
-int llhttp__internal__c_update_finish_2(
+int llhttp__internal__c_update_finish_3(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -7783,6 +8900,17 @@ int llhttp__internal__c_store_header_state(
   return 0;
 }
 
+int llhttp__internal__c_test_lenient_flags_2(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 1) == 1;
+}
+
+int llhttp__on_header_field_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
 int llhttp__internal__c_load_header_state(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -7805,6 +8933,10 @@ int llhttp__internal__c_update_header_state(
   state->header_state = 1;
   return 0;
 }
+
+int llhttp__on_header_value_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
 
 int llhttp__internal__c_or_flags_4(
     llhttp__internal_t* state,
@@ -7862,7 +8994,7 @@ int llhttp__internal__c_update_header_state_7(
   return 0;
 }
 
-int llhttp__internal__c_test_flags_7(
+int llhttp__internal__c_test_flags_2(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
@@ -7903,11 +9035,18 @@ int llhttp__internal__c_or_flags_15(
   return 0;
 }
 
-int llhttp__internal__c_test_flags_8(
+int llhttp__internal__c_test_flags_3(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
   return (state->flags & 8) == 8;
+}
+
+int llhttp__internal__c_test_lenient_flags_7(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return (state->lenient_flags & 8) == 8;
 }
 
 int llhttp__internal__c_or_flags_16(
@@ -7942,6 +9081,13 @@ int llhttp__internal__c_or_flags_18(
   return 0;
 }
 
+int llhttp__internal__c_load_method(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->method;
+}
+
 int llhttp__internal__c_store_http_major(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -7960,11 +9106,25 @@ int llhttp__internal__c_store_http_minor(
   return 0;
 }
 
-int llhttp__internal__c_is_equal_method_1(
+int llhttp__internal__c_test_lenient_flags_9(
     llhttp__internal_t* state,
     const unsigned char* p,
     const unsigned char* endp) {
-  return state->method == 33;
+  return (state->lenient_flags & 16) == 16;
+}
+
+int llhttp__internal__c_load_http_major(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->http_major;
+}
+
+int llhttp__internal__c_load_http_minor(
+    llhttp__internal_t* state,
+    const unsigned char* p,
+    const unsigned char* endp) {
+  return state->http_minor;
 }
 
 int llhttp__internal__c_update_status_code(
@@ -8006,6 +9166,10 @@ int llhttp__internal__c_mul_add_status_code(
   return 0;
 }
 
+int llhttp__on_status_complete(
+    llhttp__internal_t* s, const unsigned char* p,
+    const unsigned char* endp);
+
 int llhttp__internal__c_update_type(
     llhttp__internal_t* state,
     const unsigned char* p,
@@ -8034,9 +9198,21 @@ static llparse_state_t llhttp__internal__run(
     const unsigned char* endp) {
   int match;
   switch ((llparse_state_t) (intptr_t) state->_current) {
+    case s_n_llhttp__internal__n_closed:
+    s_n_llhttp__internal__n_closed: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_closed;
+      }
+      p++;
+      goto s_n_llhttp__internal__n_closed;
+      /* UNREACHABLE */;
+      abort();
+    }
     case s_n_llhttp__internal__n_invoke_llhttp__after_message_complete:
     s_n_llhttp__internal__n_invoke_llhttp__after_message_complete: {
       switch (llhttp__after_message_complete(state, p, endp)) {
+        case 1:
+          goto s_n_llhttp__internal__n_invoke_update_finish_2;
         default:
           goto s_n_llhttp__internal__n_invoke_update_finish_1;
       }
@@ -8176,11 +9352,38 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_chunk_parameters;
         }
         case 2: {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_size_almost_done;
+          goto s_n_llhttp__internal__n_span_end_llhttp__on_chunk_parameters;
         }
         default: {
           goto s_n_llhttp__internal__n_error_6;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters:
+    s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters;
+      }
+      state->_span_pos0 = (void*) p;
+      state->_span_cb0 = llhttp__on_chunk_parameters;
+      goto s_n_llhttp__internal__n_chunk_parameters;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_chunk_parameters_ows:
+    s_n_llhttp__internal__n_chunk_parameters_ows: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_chunk_parameters_ows;
+      }
+      switch (*p) {
+        case ' ': {
+          p++;
+          goto s_n_llhttp__internal__n_chunk_parameters_ows;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_span_start_llhttp__on_chunk_parameters;
         }
       }
       /* UNREACHABLE */;
@@ -8196,13 +9399,9 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_chunk_size_almost_done;
         }
-        case ' ': {
-          p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
-        }
         case ';': {
           p++;
-          goto s_n_llhttp__internal__n_chunk_parameters;
+          goto s_n_llhttp__internal__n_chunk_parameters_ows;
         }
         default: {
           goto s_n_llhttp__internal__n_error_7;
@@ -8526,7 +9725,7 @@ static llparse_state_t llhttp__internal__run(
         case 3:
           goto s_n_llhttp__internal__n_span_start_llhttp__on_body_1;
         case 4:
-          goto s_n_llhttp__internal__n_invoke_update_finish_2;
+          goto s_n_llhttp__internal__n_invoke_update_finish_3;
         case 5:
           goto s_n_llhttp__internal__n_error_11;
         default:
@@ -8562,13 +9761,22 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_15:
-    s_n_llhttp__internal__n_error_15: {
+    case s_n_llhttp__internal__n_error_14:
+    s_n_llhttp__internal__n_error_14: {
       state->error = 0xa;
       state->reason = "Invalid header field char";
       state->error_pos = (const char*) p;
       state->_current = (void*) (intptr_t) s_error;
       return s_error;
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete: {
+      switch (llhttp__on_header_value_complete(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_header_field_start;
+      }
       /* UNREACHABLE */;
       abort();
     }
@@ -8591,11 +9799,11 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 9: {
           p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_header_value_discard_ws;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_4;
         }
         default: {
           goto s_n_llhttp__internal__n_invoke_load_header_state;
@@ -8609,8 +9817,15 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_discard_ws_almost_done;
       }
-      p++;
-      goto s_n_llhttp__internal__n_header_value_discard_lws;
+      switch (*p) {
+        case 10: {
+          p++;
+          goto s_n_llhttp__internal__n_header_value_discard_lws;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_5;
+        }
+      }
       /* UNREACHABLE */;
       abort();
     }
@@ -8644,7 +9859,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_value_lws;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_18;
+          goto s_n_llhttp__internal__n_error_19;
         }
       }
       /* UNREACHABLE */;
@@ -8670,8 +9885,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_19:
-    s_n_llhttp__internal__n_error_19: {
+    case s_n_llhttp__internal__n_error_20:
+    s_n_llhttp__internal__n_error_20: {
       state->error = 0xa;
       state->reason = "Invalid header value char";
       state->error_pos = (const char*) p;
@@ -8690,7 +9905,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_invoke_test_flags_6;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_6;
         }
       }
       /* UNREACHABLE */;
@@ -8769,7 +9984,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_1;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob4, 4);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob3, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -8793,7 +10008,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_2;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob5, 9);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob4, 9);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -8817,7 +10032,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_connection_3;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob6, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob5, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -8867,8 +10082,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_21:
-    s_n_llhttp__internal__n_error_21: {
+    case s_n_llhttp__internal__n_error_22:
+    s_n_llhttp__internal__n_error_22: {
       state->error = 0xb;
       state->reason = "Content-Length overflow";
       state->error_pos = (const char*) p;
@@ -8877,8 +10092,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_22:
-    s_n_llhttp__internal__n_error_22: {
+    case s_n_llhttp__internal__n_error_23:
+    s_n_llhttp__internal__n_error_23: {
       state->error = 0xb;
       state->reason = "Invalid character in Content-Length";
       state->error_pos = (const char*) p;
@@ -8973,8 +10188,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_24:
-    s_n_llhttp__internal__n_error_24: {
+    case s_n_llhttp__internal__n_error_25:
+    s_n_llhttp__internal__n_error_25: {
       state->error = 0xf;
       state->reason = "Invalid `Transfer-Encoding` header value";
       state->error_pos = (const char*) p;
@@ -8983,8 +10198,8 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_error_23:
-    s_n_llhttp__internal__n_error_23: {
+    case s_n_llhttp__internal__n_error_24:
+    s_n_llhttp__internal__n_error_24: {
       state->error = 0xf;
       state->reason = "Invalid `Transfer-Encoding` header value";
       state->error_pos = (const char*) p;
@@ -9046,7 +10261,7 @@ static llparse_state_t llhttp__internal__run(
       
         /* Load input */
         input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob8);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob7);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 6,
@@ -9145,7 +10360,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_value_te_chunked;
       }
-      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob7, 7);
+      match_seq = llparse__match_sequence_to_lower_unsafe(state, p, endp, llparse_blob6, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -9185,7 +10400,7 @@ static llparse_state_t llhttp__internal__run(
         }
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_3;
         }
         case 13: {
           p++;
@@ -9202,6 +10417,15 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */;
       abort();
     }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete: {
+      switch (llhttp__on_header_field_complete(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_header_value_discard_ws;
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
     case s_n_llhttp__internal__n_header_field_general_otherwise:
     s_n_llhttp__internal__n_header_field_general_otherwise: {
       if (p == endp) {
@@ -9212,7 +10436,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_25;
+          goto s_n_llhttp__internal__n_error_26;
         }
       }
       /* UNREACHABLE */;
@@ -9250,7 +10474,7 @@ static llparse_state_t llhttp__internal__run(
       
         /* Load input */
         input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob9);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob8);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 16,
@@ -9262,7 +10486,7 @@ static llparse_state_t llhttp__internal__run(
           p += match_len;
           goto s_n_llhttp__internal__n_header_field_general;
         }
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob10);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob9);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 2,
@@ -9296,7 +10520,7 @@ static llparse_state_t llhttp__internal__run(
       }
       switch (*p) {
         case ' ': {
-          goto s_n_llhttp__internal__n_invoke_test_flags_4;
+          goto s_n_llhttp__internal__n_invoke_test_lenient_flags_2;
         }
         case ':': {
           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
@@ -9315,7 +10539,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_3;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob3, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob2, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -9340,7 +10564,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_4;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob11, 10);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob10, 10);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -9386,7 +10610,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_1;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob2, 2);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob1, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -9410,7 +10634,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_5;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob12, 15);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob11, 15);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -9435,7 +10659,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_6;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob13, 16);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob12, 16);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -9460,7 +10684,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_header_field_7;
       }
-      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob14, 6);
+      match_seq = llparse__match_sequence_to_lower(state, p, endp, llparse_blob13, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -9555,7 +10779,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_url_skip_lf_to_http09;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob14, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -9566,16 +10790,40 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_url_skip_lf_to_http09;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_26;
+          goto s_n_llhttp__internal__n_error_27;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_req_http_end_1:
-    s_n_llhttp__internal__n_req_http_end_1: {
+    case s_n_llhttp__internal__n_req_pri_upgrade:
+    s_n_llhttp__internal__n_req_pri_upgrade: {
+      llparse_match_t match_seq;
+      
       if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_end_1;
+        return s_n_llhttp__internal__n_req_pri_upgrade;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 10);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_error_32;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_req_pri_upgrade;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_33;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_complete_1:
+    s_n_llhttp__internal__n_req_http_complete_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_complete_1;
       }
       switch (*p) {
         case 10: {
@@ -9583,16 +10831,16 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_header_field_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_27;
+          goto s_n_llhttp__internal__n_error_31;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_req_http_end:
-    s_n_llhttp__internal__n_req_http_end: {
+    case s_n_llhttp__internal__n_req_http_complete:
+    s_n_llhttp__internal__n_req_http_complete: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_req_http_end;
+        return s_n_llhttp__internal__n_req_http_complete;
       }
       switch (*p) {
         case 10: {
@@ -9601,10 +10849,10 @@ static llparse_state_t llhttp__internal__run(
         }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_req_http_end_1;
+          goto s_n_llhttp__internal__n_req_http_complete_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_27;
+          goto s_n_llhttp__internal__n_error_31;
         }
       }
       /* UNREACHABLE */;
@@ -9667,7 +10915,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_28;
+          goto s_n_llhttp__internal__n_error_36;
         }
       }
       /* UNREACHABLE */;
@@ -9684,7 +10932,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_29;
+          goto s_n_llhttp__internal__n_error_37;
         }
       }
       /* UNREACHABLE */;
@@ -9747,7 +10995,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_major;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_30;
+          goto s_n_llhttp__internal__n_error_38;
         }
       }
       /* UNREACHABLE */;
@@ -9760,18 +11008,18 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_http_start_1;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob16, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob15, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_req_http_major;
+          goto s_n_llhttp__internal__n_invoke_load_method;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_req_http_start_1;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_32;
+          goto s_n_llhttp__internal__n_error_41;
         }
       }
       /* UNREACHABLE */;
@@ -9789,13 +11037,37 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_invoke_is_equal_method_1;
+          goto s_n_llhttp__internal__n_invoke_load_method_2;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_req_http_start_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_32;
+          goto s_n_llhttp__internal__n_error_41;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_req_http_start_3:
+    s_n_llhttp__internal__n_req_http_start_3: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_req_http_start_3;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          goto s_n_llhttp__internal__n_invoke_load_method_3;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_req_http_start_3;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_41;
         }
       }
       /* UNREACHABLE */;
@@ -9819,8 +11091,12 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_req_http_start_2;
         }
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_req_http_start_3;
+        }
         default: {
-          goto s_n_llhttp__internal__n_error_32;
+          goto s_n_llhttp__internal__n_error_41;
         }
       }
       /* UNREACHABLE */;
@@ -9832,7 +11108,7 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_url_skip_to_http;
       }
       p++;
-      goto s_n_llhttp__internal__n_req_http_start;
+      goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1;
       /* UNREACHABLE */;
       abort();
     }
@@ -9874,7 +11150,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_8;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_33;
+          goto s_n_llhttp__internal__n_error_42;
         }
       }
       /* UNREACHABLE */;
@@ -9931,7 +11207,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_span_end_stub_query_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_34;
+          goto s_n_llhttp__internal__n_error_43;
         }
       }
       /* UNREACHABLE */;
@@ -9961,7 +11237,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_query;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_35;
+          goto s_n_llhttp__internal__n_error_44;
         }
       }
       /* UNREACHABLE */;
@@ -9999,7 +11275,7 @@ static llparse_state_t llhttp__internal__run(
       
         /* Load input */
         input = _mm_loadu_si128((__m128i const*) p);
-        ranges = _mm_loadu_si128((__m128i const*) llparse_blob1);
+        ranges = _mm_loadu_si128((__m128i const*) llparse_blob0);
       
         /* Find first character that does not match `ranges` */
         match_len = _mm_cmpestri(ranges, 12,
@@ -10102,10 +11378,10 @@ static llparse_state_t llhttp__internal__run(
         }
         case 7: {
           p++;
-          goto s_n_llhttp__internal__n_error_36;
+          goto s_n_llhttp__internal__n_error_45;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_37;
+          goto s_n_llhttp__internal__n_error_46;
         }
       }
       /* UNREACHABLE */;
@@ -10160,7 +11436,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server_with_at;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_38;
+          goto s_n_llhttp__internal__n_error_47;
         }
       }
       /* UNREACHABLE */;
@@ -10177,7 +11453,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_server;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_40;
+          goto s_n_llhttp__internal__n_error_49;
         }
       }
       /* UNREACHABLE */;
@@ -10191,22 +11467,22 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_error_39;
+          goto s_n_llhttp__internal__n_error_48;
         }
         case 13: {
           p++;
-          goto s_n_llhttp__internal__n_error_39;
+          goto s_n_llhttp__internal__n_error_48;
         }
         case ' ': {
           p++;
-          goto s_n_llhttp__internal__n_error_39;
+          goto s_n_llhttp__internal__n_error_48;
         }
         case '/': {
           p++;
           goto s_n_llhttp__internal__n_url_schema_delim_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_40;
+          goto s_n_llhttp__internal__n_error_49;
         }
       }
       /* UNREACHABLE */;
@@ -10248,7 +11524,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_39;
+          goto s_n_llhttp__internal__n_error_48;
         }
         case 2: {
           goto s_n_llhttp__internal__n_span_end_stub_schema;
@@ -10258,7 +11534,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_41;
+          goto s_n_llhttp__internal__n_error_50;
         }
       }
       /* UNREACHABLE */;
@@ -10290,7 +11566,7 @@ static llparse_state_t llhttp__internal__run(
       switch (lookup_table[(uint8_t) *p]) {
         case 1: {
           p++;
-          goto s_n_llhttp__internal__n_error_39;
+          goto s_n_llhttp__internal__n_error_48;
         }
         case 2: {
           goto s_n_llhttp__internal__n_span_start_stub_path_2;
@@ -10299,7 +11575,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_url_schema;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_42;
+          goto s_n_llhttp__internal__n_error_51;
         }
       }
       /* UNREACHABLE */;
@@ -10355,32 +11631,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_spaces_before_url;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_43;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_1:
-    s_n_llhttp__internal__n_start_req_1: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_1;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob0, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 19;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_1;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_52;
         }
       }
       /* UNREACHABLE */;
@@ -10388,24 +11639,63 @@ static llparse_state_t llhttp__internal__run(
     }
     case s_n_llhttp__internal__n_start_req_2:
     s_n_llhttp__internal__n_start_req_2: {
-      llparse_match_t match_seq;
-      
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob18, 3);
+      switch (*p) {
+        case 'L': {
+          p++;
+          match = 19;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_3:
+    s_n_llhttp__internal__n_start_req_3: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_3;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 16;
+          match = 36;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_2;
+          return s_n_llhttp__internal__n_start_req_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_1:
+    s_n_llhttp__internal__n_start_req_1: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_1;
+      }
+      switch (*p) {
+        case 'C': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_2;
+        }
+        case 'N': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_3;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10418,19 +11708,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_4;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob19, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 22;
+          match = 16;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_4;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10443,79 +11733,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_6;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob20, 4);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 5;
+          match = 22;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_6;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_7:
-    s_n_llhttp__internal__n_start_req_7: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_7;
-      }
-      switch (*p) {
-        case 'Y': {
-          p++;
-          match = 8;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_5:
-    s_n_llhttp__internal__n_start_req_5: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_5;
-      }
-      switch (*p) {
-        case 'N': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_6;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_7;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_3:
-    s_n_llhttp__internal__n_start_req_3: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_3;
-      }
-      switch (*p) {
-        case 'H': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_4;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_5;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10528,19 +11758,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_8;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob21, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 4);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 0;
+          match = 5;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_8;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10548,49 +11778,59 @@ static llparse_state_t llhttp__internal__run(
     }
     case s_n_llhttp__internal__n_start_req_9:
     s_n_llhttp__internal__n_start_req_9: {
-      llparse_match_t match_seq;
-      
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_9;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob22, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
+      switch (*p) {
+        case 'Y': {
           p++;
-          match = 1;
+          match = 8;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_9;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_10:
-    s_n_llhttp__internal__n_start_req_10: {
-      llparse_match_t match_seq;
-      
+    case s_n_llhttp__internal__n_start_req_7:
+    s_n_llhttp__internal__n_start_req_7: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_10;
+        return s_n_llhttp__internal__n_start_req_7;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
+      switch (*p) {
+        case 'N': {
           p++;
-          match = 2;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
+          goto s_n_llhttp__internal__n_start_req_8;
         }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_10;
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_9;
         }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_5:
+    s_n_llhttp__internal__n_start_req_5: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_5;
+      }
+      switch (*p) {
+        case 'H': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_6;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_7;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10603,19 +11843,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_12;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob23, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 31;
+          match = 0;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_12;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10628,19 +11868,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_13;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob24, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 9;
+          match = 35;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_13;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10652,16 +11892,101 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_start_req_11;
       }
       switch (*p) {
-        case 'I': {
+        case 'L': {
           p++;
           goto s_n_llhttp__internal__n_start_req_12;
         }
-        case 'O': {
+        case 'S': {
           p++;
           goto s_n_llhttp__internal__n_start_req_13;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_10:
+    s_n_llhttp__internal__n_start_req_10: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_10;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_11;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_14:
+    s_n_llhttp__internal__n_start_req_14: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_14;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob25, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 45;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_14;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_17:
+    s_n_llhttp__internal__n_start_req_17: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_17;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 9);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 41;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_17;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_16:
+    s_n_llhttp__internal__n_start_req_16: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_16;
+      }
+      switch (*p) {
+        case '_': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_17;
+        }
+        default: {
+          match = 1;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
       }
       /* UNREACHABLE */;
@@ -10674,44 +11999,18 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_15;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob26, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 24;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
+          goto s_n_llhttp__internal__n_start_req_16;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_15;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_16:
-    s_n_llhttp__internal__n_start_req_16: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_16;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob27, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 23;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_16;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10724,19 +12023,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_18;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 7);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob28, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 21;
+          match = 2;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_18;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10749,19 +12048,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_20;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob29, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 30;
+          match = 31;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_20;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10769,17 +12068,24 @@ static llparse_state_t llhttp__internal__run(
     }
     case s_n_llhttp__internal__n_start_req_21:
     s_n_llhttp__internal__n_start_req_21: {
+      llparse_match_t match_seq;
+      
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_21;
       }
-      switch (*p) {
-        case 'L': {
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
           p++;
-          match = 10;
+          match = 9;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_21;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10791,7 +12097,7 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_start_req_19;
       }
       switch (*p) {
-        case 'A': {
+        case 'I': {
           p++;
           goto s_n_llhttp__internal__n_start_req_20;
         }
@@ -10800,82 +12106,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_start_req_21;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_17:
-    s_n_llhttp__internal__n_start_req_17: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_17;
-      }
-      switch (*p) {
-        case 'A': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_18;
-        }
-        case 'C': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_19;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_22:
-    s_n_llhttp__internal__n_start_req_22: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_22;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob30, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 11;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_22;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_14:
-    s_n_llhttp__internal__n_start_req_14: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_14;
-      }
-      switch (*p) {
-        case '-': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_15;
-        }
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_16;
-        }
-        case 'K': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_17;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_22;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10888,19 +12119,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_23;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob31, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 25;
+          match = 24;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_23;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10913,19 +12144,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_24;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 6);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob32, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 6;
+          match = 23;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_24;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -10938,115 +12169,44 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_26;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob33, 7);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 28;
+          match = 21;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_26;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_27:
-    s_n_llhttp__internal__n_start_req_27: {
+    case s_n_llhttp__internal__n_start_req_28:
+    s_n_llhttp__internal__n_start_req_28: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_27;
+        return s_n_llhttp__internal__n_start_req_28;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob34, 6);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 3;
+          match = 30;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_27;
+          return s_n_llhttp__internal__n_start_req_28;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_31:
-    s_n_llhttp__internal__n_start_req_31: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_31;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 3);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 12;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_31;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_32:
-    s_n_llhttp__internal__n_start_req_32: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_32;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 13;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_32;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_30:
-    s_n_llhttp__internal__n_start_req_30: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_30;
-      }
-      switch (*p) {
-        case 'F': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_31;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_32;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11058,81 +12218,34 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_start_req_29;
       }
       switch (*p) {
-        case 'P': {
+        case 'L': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_30;
+          match = 10;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_28:
-    s_n_llhttp__internal__n_start_req_28: {
+    case s_n_llhttp__internal__n_start_req_27:
+    s_n_llhttp__internal__n_start_req_27: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_28;
+        return s_n_llhttp__internal__n_start_req_27;
       }
       switch (*p) {
-        case 'I': {
+        case 'A': {
           p++;
-          match = 34;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
+          goto s_n_llhttp__internal__n_start_req_28;
         }
         case 'O': {
           p++;
           goto s_n_llhttp__internal__n_start_req_29;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_34:
-    s_n_llhttp__internal__n_start_req_34: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_34;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 2);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 29;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_34;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_33:
-    s_n_llhttp__internal__n_start_req_33: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_33;
-      }
-      switch (*p) {
-        case 'R': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_34;
-        }
-        case 'T': {
-          p++;
-          match = 4;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11148,20 +12261,187 @@ static llparse_state_t llhttp__internal__run(
           p++;
           goto s_n_llhttp__internal__n_start_req_26;
         }
-        case 'O': {
+        case 'C': {
           p++;
           goto s_n_llhttp__internal__n_start_req_27;
         }
-        case 'R': {
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_30:
+    s_n_llhttp__internal__n_start_req_30: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_30;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob35, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
           p++;
-          goto s_n_llhttp__internal__n_start_req_28;
+          match = 11;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_30;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_22:
+    s_n_llhttp__internal__n_start_req_22: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_22;
+      }
+      switch (*p) {
+        case '-': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_23;
+        }
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_24;
+        }
+        case 'K': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_25;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_30;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_31:
+    s_n_llhttp__internal__n_start_req_31: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_31;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob36, 5);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 25;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_31;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_32:
+    s_n_llhttp__internal__n_start_req_32: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_32;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob37, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 6;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_32;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_35:
+    s_n_llhttp__internal__n_start_req_35: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_35;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 28;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_35;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_36:
+    s_n_llhttp__internal__n_start_req_36: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_36;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 39;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_36;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_34:
+    s_n_llhttp__internal__n_start_req_34: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_34;
+      }
+      switch (*p) {
+        case 'T': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_35;
         }
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_33;
+          goto s_n_llhttp__internal__n_start_req_36;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11174,19 +12454,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_37;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob38, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 17;
+          match = 38;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_37;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11199,107 +12479,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_38;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob39, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 20;
+          match = 3;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_38;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_36:
-    s_n_llhttp__internal__n_start_req_36: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_36;
-      }
-      switch (*p) {
-        case 'B': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_37;
-        }
-        case 'P': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_38;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_35:
-    s_n_llhttp__internal__n_start_req_35: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_35;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_36;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_40:
-    s_n_llhttp__internal__n_start_req_40: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_40;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob40, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 14;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_40;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_41:
-    s_n_llhttp__internal__n_start_req_41: {
-      llparse_match_t match_seq;
-      
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_41;
-      }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob41, 4);
-      p = match_seq.current;
-      switch (match_seq.status) {
-        case kMatchComplete: {
-          p++;
-          match = 33;
-          goto s_n_llhttp__internal__n_invoke_store_method_1;
-        }
-        case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_41;
-        }
-        case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11312,44 +12504,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_42;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 7);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob42, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 26;
+          match = 12;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_42;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_39:
-    s_n_llhttp__internal__n_start_req_39: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_39;
-      }
-      switch (*p) {
-        case 'E': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_40;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_41;
-        }
-        case 'U': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_42;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11367,39 +12534,154 @@ static llparse_state_t llhttp__internal__run(
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 7;
+          match = 13;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_43;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_46:
-    s_n_llhttp__internal__n_start_req_46: {
+    case s_n_llhttp__internal__n_start_req_41:
+    s_n_llhttp__internal__n_start_req_41: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_41;
+      }
+      switch (*p) {
+        case 'F': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_42;
+        }
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_43;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_40:
+    s_n_llhttp__internal__n_start_req_40: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_40;
+      }
+      switch (*p) {
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_41;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_39:
+    s_n_llhttp__internal__n_start_req_39: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_39;
+      }
+      switch (*p) {
+        case 'I': {
+          p++;
+          match = 34;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_40;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_45:
+    s_n_llhttp__internal__n_start_req_45: {
       llparse_match_t match_seq;
       
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_46;
+        return s_n_llhttp__internal__n_start_req_45;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob44, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 18;
+          match = 29;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_46;
+          return s_n_llhttp__internal__n_start_req_45;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_44:
+    s_n_llhttp__internal__n_start_req_44: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_44;
+      }
+      switch (*p) {
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_45;
+        }
+        case 'T': {
+          p++;
+          match = 4;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_33:
+    s_n_llhttp__internal__n_start_req_33: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_33;
+      }
+      switch (*p) {
+        case 'A': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_34;
+        }
+        case 'L': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_37;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_38;
+        }
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_39;
+        }
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_44;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11412,19 +12694,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_48;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob45, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 32;
+          match = 17;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_48;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11437,40 +12719,19 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_49;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob46, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
           p++;
-          match = 15;
+          match = 44;
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
           return s_n_llhttp__internal__n_start_req_49;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
-        }
-      }
-      /* UNREACHABLE */;
-      abort();
-    }
-    case s_n_llhttp__internal__n_start_req_47:
-    s_n_llhttp__internal__n_start_req_47: {
-      if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_47;
-      }
-      switch (*p) {
-        case 'I': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_48;
-        }
-        case 'O': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_49;
-        }
-        default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11483,7 +12744,455 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_req_50;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 8);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob47, 5);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 43;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_50;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_51:
+    s_n_llhttp__internal__n_start_req_51: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_51;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 20;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_51;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_47:
+    s_n_llhttp__internal__n_start_req_47: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_47;
+      }
+      switch (*p) {
+        case 'B': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_48;
+        }
+        case 'C': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_49;
+        }
+        case 'D': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_50;
+        }
+        case 'P': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_51;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_46:
+    s_n_llhttp__internal__n_start_req_46: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_46;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_47;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_54:
+    s_n_llhttp__internal__n_start_req_54: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_54;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 14;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_54;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_56:
+    s_n_llhttp__internal__n_start_req_56: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_56;
+      }
+      switch (*p) {
+        case 'P': {
+          p++;
+          match = 37;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_57:
+    s_n_llhttp__internal__n_start_req_57: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_57;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 9);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 42;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_57;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_55:
+    s_n_llhttp__internal__n_start_req_55: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_55;
+      }
+      switch (*p) {
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_56;
+        }
+        case '_': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_57;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_53:
+    s_n_llhttp__internal__n_start_req_53: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_53;
+      }
+      switch (*p) {
+        case 'A': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_54;
+        }
+        case 'T': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_55;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_58:
+    s_n_llhttp__internal__n_start_req_58: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_58;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob51, 4);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 33;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_58;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_59:
+    s_n_llhttp__internal__n_start_req_59: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_59;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob52, 7);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 26;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_59;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_52:
+    s_n_llhttp__internal__n_start_req_52: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_52;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_53;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_58;
+        }
+        case 'U': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_59;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_61:
+    s_n_llhttp__internal__n_start_req_61: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_61;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob53, 6);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 40;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_61;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_62:
+    s_n_llhttp__internal__n_start_req_62: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_62;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob54, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 7;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_62;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_60:
+    s_n_llhttp__internal__n_start_req_60: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_60;
+      }
+      switch (*p) {
+        case 'E': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_61;
+        }
+        case 'R': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_62;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_65:
+    s_n_llhttp__internal__n_start_req_65: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_65;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob55, 3);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 18;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_65;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_67:
+    s_n_llhttp__internal__n_start_req_67: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_67;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob56, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 32;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_67;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_68:
+    s_n_llhttp__internal__n_start_req_68: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_68;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob57, 2);
+      p = match_seq.current;
+      switch (match_seq.status) {
+        case kMatchComplete: {
+          p++;
+          match = 15;
+          goto s_n_llhttp__internal__n_invoke_store_method_1;
+        }
+        case kMatchPause: {
+          return s_n_llhttp__internal__n_start_req_68;
+        }
+        case kMatchMismatch: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_66:
+    s_n_llhttp__internal__n_start_req_66: {
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_66;
+      }
+      switch (*p) {
+        case 'I': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_67;
+        }
+        case 'O': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_68;
+        }
+        default: {
+          goto s_n_llhttp__internal__n_error_64;
+        }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_start_req_69:
+    s_n_llhttp__internal__n_start_req_69: {
+      llparse_match_t match_seq;
+      
+      if (p == endp) {
+        return s_n_llhttp__internal__n_start_req_69;
+      }
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob58, 8);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -11492,52 +13201,52 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_method_1;
         }
         case kMatchPause: {
-          return s_n_llhttp__internal__n_start_req_50;
+          return s_n_llhttp__internal__n_start_req_69;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_45:
-    s_n_llhttp__internal__n_start_req_45: {
+    case s_n_llhttp__internal__n_start_req_64:
+    s_n_llhttp__internal__n_start_req_64: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_45;
+        return s_n_llhttp__internal__n_start_req_64;
       }
       switch (*p) {
         case 'B': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_46;
+          goto s_n_llhttp__internal__n_start_req_65;
         }
         case 'L': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_47;
+          goto s_n_llhttp__internal__n_start_req_66;
         }
         case 'S': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_50;
+          goto s_n_llhttp__internal__n_start_req_69;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
       abort();
     }
-    case s_n_llhttp__internal__n_start_req_44:
-    s_n_llhttp__internal__n_start_req_44: {
+    case s_n_llhttp__internal__n_start_req_63:
+    s_n_llhttp__internal__n_start_req_63: {
       if (p == endp) {
-        return s_n_llhttp__internal__n_start_req_44;
+        return s_n_llhttp__internal__n_start_req_63;
       }
       switch (*p) {
         case 'N': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_45;
+          goto s_n_llhttp__internal__n_start_req_64;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
       }
       /* UNREACHABLE */;
@@ -11555,63 +13264,76 @@ static llparse_state_t llhttp__internal__run(
         }
         case 'B': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_2;
+          goto s_n_llhttp__internal__n_start_req_4;
         }
         case 'C': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_3;
+          goto s_n_llhttp__internal__n_start_req_5;
         }
         case 'D': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_8;
-        }
-        case 'G': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_9;
-        }
-        case 'H': {
-          p++;
           goto s_n_llhttp__internal__n_start_req_10;
         }
-        case 'L': {
-          p++;
-          goto s_n_llhttp__internal__n_start_req_11;
-        }
-        case 'M': {
+        case 'F': {
           p++;
           goto s_n_llhttp__internal__n_start_req_14;
         }
+        case 'G': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_15;
+        }
+        case 'H': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_18;
+        }
+        case 'L': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_19;
+        }
+        case 'M': {
+          p++;
+          goto s_n_llhttp__internal__n_start_req_22;
+        }
         case 'N': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_23;
+          goto s_n_llhttp__internal__n_start_req_31;
         }
         case 'O': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_24;
+          goto s_n_llhttp__internal__n_start_req_32;
         }
         case 'P': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_25;
+          goto s_n_llhttp__internal__n_start_req_33;
         }
         case 'R': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_35;
+          goto s_n_llhttp__internal__n_start_req_46;
         }
         case 'S': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_39;
+          goto s_n_llhttp__internal__n_start_req_52;
         }
         case 'T': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_43;
+          goto s_n_llhttp__internal__n_start_req_60;
         }
         case 'U': {
           p++;
-          goto s_n_llhttp__internal__n_start_req_44;
+          goto s_n_llhttp__internal__n_start_req_63;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_51;
+          goto s_n_llhttp__internal__n_error_64;
         }
+      }
+      /* UNREACHABLE */;
+      abort();
+    }
+    case s_n_llhttp__internal__n_invoke_llhttp__on_status_complete:
+    s_n_llhttp__internal__n_invoke_llhttp__on_status_complete: {
+      switch (llhttp__on_status_complete(state, p, endp)) {
+        default:
+          goto s_n_llhttp__internal__n_header_field_start;
       }
       /* UNREACHABLE */;
       abort();
@@ -11622,7 +13344,7 @@ static llparse_state_t llhttp__internal__run(
         return s_n_llhttp__internal__n_res_line_almost_done;
       }
       p++;
-      goto s_n_llhttp__internal__n_header_field_start;
+      goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
       /* UNREACHABLE */;
       abort();
     }
@@ -11665,7 +13387,7 @@ static llparse_state_t llhttp__internal__run(
       switch (*p) {
         case 10: {
           p++;
-          goto s_n_llhttp__internal__n_header_field_start;
+          goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
         }
         case 13: {
           p++;
@@ -11695,7 +13417,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_res_status_start;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_45;
+          goto s_n_llhttp__internal__n_error_56;
         }
       }
       /* UNREACHABLE */;
@@ -11775,7 +13497,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_update_status_code;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_46;
+          goto s_n_llhttp__internal__n_error_57;
         }
       }
       /* UNREACHABLE */;
@@ -11838,7 +13560,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_47;
+          goto s_n_llhttp__internal__n_error_60;
         }
       }
       /* UNREACHABLE */;
@@ -11855,7 +13577,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_res_http_minor;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_48;
+          goto s_n_llhttp__internal__n_error_61;
         }
       }
       /* UNREACHABLE */;
@@ -11918,7 +13640,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_invoke_store_http_major_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_49;
+          goto s_n_llhttp__internal__n_error_62;
         }
       }
       /* UNREACHABLE */;
@@ -11931,7 +13653,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_start_res;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob48, 5);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob59, 5);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -11942,7 +13664,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_start_res;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_52;
+          goto s_n_llhttp__internal__n_error_65;
         }
       }
       /* UNREACHABLE */;
@@ -11955,7 +13677,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_or_res_method_2;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob49, 2);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob60, 2);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -11967,7 +13689,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_2;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_50;
+          goto s_n_llhttp__internal__n_error_63;
         }
       }
       /* UNREACHABLE */;
@@ -11980,7 +13702,7 @@ static llparse_state_t llhttp__internal__run(
       if (p == endp) {
         return s_n_llhttp__internal__n_req_or_res_method_3;
       }
-      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob50, 3);
+      match_seq = llparse__match_sequence_id(state, p, endp, llparse_blob61, 3);
       p = match_seq.current;
       switch (match_seq.status) {
         case kMatchComplete: {
@@ -11991,7 +13713,7 @@ static llparse_state_t llhttp__internal__run(
           return s_n_llhttp__internal__n_req_or_res_method_3;
         }
         case kMatchMismatch: {
-          goto s_n_llhttp__internal__n_error_50;
+          goto s_n_llhttp__internal__n_error_63;
         }
       }
       /* UNREACHABLE */;
@@ -12012,7 +13734,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_3;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_50;
+          goto s_n_llhttp__internal__n_error_63;
         }
       }
       /* UNREACHABLE */;
@@ -12029,7 +13751,7 @@ static llparse_state_t llhttp__internal__run(
           goto s_n_llhttp__internal__n_req_or_res_method_1;
         }
         default: {
-          goto s_n_llhttp__internal__n_error_50;
+          goto s_n_llhttp__internal__n_error_63;
         }
       }
       /* UNREACHABLE */;
@@ -12089,7 +13811,7 @@ static llparse_state_t llhttp__internal__run(
       /* UNREACHABLE */
       abort();
   }
-  s_n_llhttp__internal__n_error_39: {
+  s_n_llhttp__internal__n_error_48: {
     state->error = 0x7;
     state->reason = "Invalid characters in url";
     state->error_pos = (const char*) p;
@@ -12098,10 +13820,28 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_finish_1: {
+  s_n_llhttp__internal__n_invoke_update_finish_2: {
     switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags: {
+    switch (llhttp__internal__c_test_lenient_flags(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_update_finish_2;
+      default:
+        goto s_n_llhttp__internal__n_closed;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_update_finish_1: {
+    switch (llhttp__internal__c_update_finish_1(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags;
     }
     /* UNREACHABLE */;
     abort();
@@ -12133,7 +13873,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_14: {
+  s_n_llhttp__internal__n_error_13: {
     state->error = 0x14;
     state->reason = "`on_chunk_complete` callback error";
     state->error_pos = (const char*) p;
@@ -12149,7 +13889,7 @@ static llparse_state_t llhttp__internal__run(
       case 21:
         goto s_n_llhttp__internal__n_pause_7;
       default:
-        goto s_n_llhttp__internal__n_error_14;
+        goto s_n_llhttp__internal__n_error_13;
     }
     /* UNREACHABLE */;
     abort();
@@ -12157,15 +13897,6 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_error_12: {
     state->error = 0x4;
     state->reason = "Content-Length can't be present with Transfer-Encoding";
-    state->error_pos = (const char*) p;
-    state->_current = (void*) (intptr_t) s_error;
-    return s_error;
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_error_13: {
-    state->error = 0x4;
-    state->reason = "Content-Length can't be present with chunked encoding";
     state->error_pos = (const char*) p;
     state->_current = (void*) (intptr_t) s_error;
     return s_error;
@@ -12296,6 +14027,24 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_span_end_llhttp__on_chunk_parameters: {
+    const unsigned char* start;
+    int err;
+    
+    start = state->_span_pos0;
+    state->_span_pos0 = NULL;
+    err = llhttp__on_chunk_parameters(state, start, p);
+    if (err != 0) {
+      state->error = err;
+      state->error_pos = (const char*) (p + 1);
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_chunk_size_almost_done;
+      return s_error;
+    }
+    p++;
+    goto s_n_llhttp__internal__n_chunk_size_almost_done;
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_error_6: {
     state->error = 0x2;
     state->reason = "Invalid character in chunk parameters";
@@ -12350,8 +14099,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_update_finish_2: {
-    switch (llhttp__internal__c_update_finish_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_update_finish_3: {
+    switch (llhttp__internal__c_update_finish_3(state, p, endp)) {
       default:
         goto s_n_llhttp__internal__n_span_start_llhttp__on_body_2;
     }
@@ -12463,22 +14212,10 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_3: {
-    switch (llhttp__internal__c_test_flags_3(state, p, endp)) {
-      case 1:
-        goto s_n_llhttp__internal__n_error_13;
-      default:
-        goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
-    }
-    /* UNREACHABLE */;
-    abort();
-  }
-  s_n_llhttp__internal__n_invoke_test_flags_2: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_1: {
+    switch (llhttp__internal__c_test_lenient_flags_1(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_error_12;
-      case 1:
-        goto s_n_llhttp__internal__n_invoke_test_flags_3;
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
     }
@@ -12488,7 +14225,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_test_flags_1: {
     switch (llhttp__internal__c_test_flags_1(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_flags_2;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_1;
       default:
         goto s_n_llhttp__internal__n_invoke_llhttp__before_headers_complete;
     }
@@ -12515,20 +14252,39 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_15;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_14;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_15;
+    goto s_n_llhttp__internal__n_error_14;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_4: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_2: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_field_colon_discard_ws;
       default:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_16: {
+    state->error = 0xa;
+    state->reason = "Invalid header value char";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_4: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_discard_ws;
+      default:
+        goto s_n_llhttp__internal__n_error_16;
     }
     /* UNREACHABLE */;
     abort();
@@ -12552,10 +14308,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_field_start;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_header_field_start;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     /* UNREACHABLE */;
     abort();
   }
@@ -12625,7 +14381,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_16: {
+  s_n_llhttp__internal__n_error_15: {
     state->error = 0xa;
     state->reason = "Invalid header value char";
     state->error_pos = (const char*) p;
@@ -12634,12 +14390,31 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_5: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_3: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_discard_lws;
       default:
-        goto s_n_llhttp__internal__n_error_16;
+        goto s_n_llhttp__internal__n_error_15;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_18: {
+    state->error = 0x2;
+    state->reason = "Expected LF after CR";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_5: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_header_value_discard_lws;
+      default:
+        goto s_n_llhttp__internal__n_error_18;
     }
     /* UNREACHABLE */;
     abort();
@@ -12665,7 +14440,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_update_header_state_2: {
     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     }
     /* UNREACHABLE */;
     abort();
@@ -12697,7 +14472,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_or_flags_10: {
     switch (llhttp__internal__c_or_flags_6(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     }
     /* UNREACHABLE */;
     abort();
@@ -12713,12 +14488,12 @@ static llparse_state_t llhttp__internal__run(
       case 8:
         goto s_n_llhttp__internal__n_invoke_or_flags_10;
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_header_value_complete;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_18: {
+  s_n_llhttp__internal__n_error_19: {
     state->error = 0x3;
     state->reason = "Missing expected LF after header value";
     state->error_pos = (const char*) p;
@@ -12790,15 +14565,15 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_19;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_20;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_19;
+    goto s_n_llhttp__internal__n_error_20;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_6: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_6: {
+    switch (llhttp__internal__c_test_lenient_flags_2(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_header_value_lenient;
       default:
@@ -12905,10 +14680,10 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_21;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_22;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_21;
+    goto s_n_llhttp__internal__n_error_22;
     /* UNREACHABLE */;
     abort();
   }
@@ -12940,14 +14715,14 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) p;
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_22;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_23;
       return s_error;
     }
-    goto s_n_llhttp__internal__n_error_22;
+    goto s_n_llhttp__internal__n_error_23;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_20: {
+  s_n_llhttp__internal__n_error_21: {
     state->error = 0x4;
     state->reason = "Duplicate Content-Length";
     state->error_pos = (const char*) p;
@@ -12956,12 +14731,12 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_7: {
-    switch (llhttp__internal__c_test_flags_7(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_flags_2: {
+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_header_value_content_length;
       default:
-        goto s_n_llhttp__internal__n_error_20;
+        goto s_n_llhttp__internal__n_error_21;
     }
     /* UNREACHABLE */;
     abort();
@@ -12976,11 +14751,11 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_24;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_25;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_24;
+    goto s_n_llhttp__internal__n_error_25;
     /* UNREACHABLE */;
     abort();
   }
@@ -13002,16 +14777,16 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_23;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_24;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_error_23;
+    goto s_n_llhttp__internal__n_error_24;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_9: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_7: {
+    switch (llhttp__internal__c_test_lenient_flags_7(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
       default:
@@ -13023,7 +14798,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_type_1: {
     switch (llhttp__internal__c_load_type(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_flags_9;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_7;
       default:
         goto s_n_llhttp__internal__n_header_value_te_chunked;
     }
@@ -13054,8 +14829,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_10: {
-    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_8: {
+    switch (llhttp__internal__c_test_lenient_flags_7(state, p, endp)) {
       case 0:
         goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
       default:
@@ -13067,7 +14842,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_load_type_2: {
     switch (llhttp__internal__c_load_type(state, p, endp)) {
       case 1:
-        goto s_n_llhttp__internal__n_invoke_test_flags_10;
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_8;
       default:
         goto s_n_llhttp__internal__n_invoke_or_flags_17;
     }
@@ -13082,8 +14857,8 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_test_flags_8: {
-    switch (llhttp__internal__c_test_flags_8(state, p, endp)) {
+  s_n_llhttp__internal__n_invoke_test_flags_3: {
+    switch (llhttp__internal__c_test_flags_3(state, p, endp)) {
       case 1:
         goto s_n_llhttp__internal__n_invoke_load_type_2;
       default:
@@ -13105,9 +14880,9 @@ static llparse_state_t llhttp__internal__run(
       case 1:
         goto s_n_llhttp__internal__n_header_value_connection;
       case 2:
-        goto s_n_llhttp__internal__n_invoke_test_flags_7;
+        goto s_n_llhttp__internal__n_invoke_test_flags_2;
       case 3:
-        goto s_n_llhttp__internal__n_invoke_test_flags_8;
+        goto s_n_llhttp__internal__n_invoke_test_flags_3;
       case 4:
         goto s_n_llhttp__internal__n_invoke_or_flags_18;
       default:
@@ -13126,11 +14901,11 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_header_value_discard_ws;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
     /* UNREACHABLE */;
     abort();
   }
@@ -13144,15 +14919,15 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_discard_ws;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_header_value_discard_ws;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_header_field_complete;
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_25: {
+  s_n_llhttp__internal__n_error_26: {
     state->error = 0xa;
     state->reason = "Invalid header token";
     state->error_pos = (const char*) p;
@@ -13185,10 +14960,18 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
+  s_n_llhttp__internal__n_invoke_llhttp__on_url_complete: {
+    switch (llhttp__on_url_complete(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_header_field_start;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
   s_n_llhttp__internal__n_invoke_update_http_minor: {
     switch (llhttp__internal__c_update_http_minor(state, p, endp)) {
       default:
-        goto s_n_llhttp__internal__n_header_field_start;
+        goto s_n_llhttp__internal__n_invoke_llhttp__on_url_complete;
     }
     /* UNREACHABLE */;
     abort();
@@ -13218,7 +15001,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_26: {
+  s_n_llhttp__internal__n_error_27: {
     state->error = 0x7;
     state->reason = "Expected CRLF";
     state->error_pos = (const char*) p;
@@ -13244,7 +15027,25 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_27: {
+  s_n_llhttp__internal__n_error_32: {
+    state->error = 0x17;
+    state->reason = "Pause on PRI/Upgrade";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_33: {
+    state->error = 0x9;
+    state->reason = "Expected HTTP/2 Connection Preface";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_31: {
     state->error = 0x9;
     state->reason = "Expected CRLF after version";
     state->error_pos = (const char*) p;
@@ -13253,15 +15054,117 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_store_http_minor: {
-    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
+  s_n_llhttp__internal__n_invoke_load_method_1: {
+    switch (llhttp__internal__c_load_method(state, p, endp)) {
+      case 34:
+        goto s_n_llhttp__internal__n_req_pri_upgrade;
       default:
-        goto s_n_llhttp__internal__n_req_http_end;
+        goto s_n_llhttp__internal__n_req_http_complete;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_28: {
+  s_n_llhttp__internal__n_error_30: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 9:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      default:
+        goto s_n_llhttp__internal__n_error_30;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_34: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_1: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      default:
+        goto s_n_llhttp__internal__n_error_34;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_35: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_2: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      default:
+        goto s_n_llhttp__internal__n_error_35;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_29: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_major: {
+    switch (llhttp__internal__c_load_http_major(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_1;
+      case 2:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_2;
+      default:
+        goto s_n_llhttp__internal__n_error_29;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_9: {
+    switch (llhttp__internal__c_test_lenient_flags_9(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_load_method_1;
+      default:
+        goto s_n_llhttp__internal__n_invoke_load_http_major;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_http_minor: {
+    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_9;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_36: {
     state->error = 0x9;
     state->reason = "Invalid minor version";
     state->error_pos = (const char*) p;
@@ -13270,7 +15173,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_29: {
+  s_n_llhttp__internal__n_error_37: {
     state->error = 0x9;
     state->reason = "Expected dot";
     state->error_pos = (const char*) p;
@@ -13287,7 +15190,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_30: {
+  s_n_llhttp__internal__n_error_38: {
     state->error = 0x9;
     state->reason = "Invalid major version";
     state->error_pos = (const char*) p;
@@ -13296,7 +15199,94 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_32: {
+  s_n_llhttp__internal__n_error_28: {
+    state->error = 0x8;
+    state->reason = "Invalid method for HTTP/x.x request";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_method: {
+    switch (llhttp__internal__c_load_method(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 1:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 2:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 3:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 4:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 5:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 6:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 7:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 8:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 9:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 10:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 11:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 12:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 13:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 14:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 15:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 16:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 17:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 18:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 19:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 20:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 21:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 22:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 23:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 24:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 25:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 26:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 27:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 28:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 29:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 30:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 31:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 32:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 33:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 34:
+        goto s_n_llhttp__internal__n_req_http_major;
+      default:
+        goto s_n_llhttp__internal__n_error_28;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_41: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -13305,7 +15295,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_31: {
+  s_n_llhttp__internal__n_error_39: {
     state->error = 0x8;
     state->reason = "Expected SOURCE method for ICE/x.x request";
     state->error_pos = (const char*) p;
@@ -13314,12 +15304,65 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_is_equal_method_1: {
-    switch (llhttp__internal__c_is_equal_method_1(state, p, endp)) {
-      case 0:
-        goto s_n_llhttp__internal__n_error_31;
-      default:
+  s_n_llhttp__internal__n_invoke_load_method_2: {
+    switch (llhttp__internal__c_load_method(state, p, endp)) {
+      case 33:
         goto s_n_llhttp__internal__n_req_http_major;
+      default:
+        goto s_n_llhttp__internal__n_error_39;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_40: {
+    state->error = 0x8;
+    state->reason = "Invalid method for RTSP/x.x request";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_method_3: {
+    switch (llhttp__internal__c_load_method(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 3:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 6:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 35:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 36:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 37:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 38:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 39:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 40:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 41:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 42:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 43:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 44:
+        goto s_n_llhttp__internal__n_req_http_major;
+      case 45:
+        goto s_n_llhttp__internal__n_req_http_major;
+      default:
+        goto s_n_llhttp__internal__n_error_40;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_llhttp__on_url_complete_1: {
+    switch (llhttp__on_url_complete(state, p, endp)) {
+      default:
+        goto s_n_llhttp__internal__n_req_http_start;
     }
     /* UNREACHABLE */;
     abort();
@@ -13392,7 +15435,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_33: {
+  s_n_llhttp__internal__n_error_42: {
     state->error = 0x7;
     state->reason = "Invalid char in url fragment start";
     state->error_pos = (const char*) p;
@@ -13452,7 +15495,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_34: {
+  s_n_llhttp__internal__n_error_43: {
     state->error = 0x7;
     state->reason = "Invalid char in url query";
     state->error_pos = (const char*) p;
@@ -13461,7 +15504,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_35: {
+  s_n_llhttp__internal__n_error_44: {
     state->error = 0x7;
     state->reason = "Invalid char in url path";
     state->error_pos = (const char*) p;
@@ -13572,7 +15615,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_36: {
+  s_n_llhttp__internal__n_error_45: {
     state->error = 0x7;
     state->reason = "Double @ in url";
     state->error_pos = (const char*) p;
@@ -13581,7 +15624,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_37: {
+  s_n_llhttp__internal__n_error_46: {
     state->error = 0x7;
     state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
@@ -13590,7 +15633,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_38: {
+  s_n_llhttp__internal__n_error_47: {
     state->error = 0x7;
     state->reason = "Unexpected char in url server";
     state->error_pos = (const char*) p;
@@ -13599,7 +15642,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_40: {
+  s_n_llhttp__internal__n_error_49: {
     state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
@@ -13608,7 +15651,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_41: {
+  s_n_llhttp__internal__n_error_50: {
     state->error = 0x7;
     state->reason = "Unexpected char in url schema";
     state->error_pos = (const char*) p;
@@ -13617,7 +15660,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_42: {
+  s_n_llhttp__internal__n_error_51: {
     state->error = 0x7;
     state->reason = "Unexpected start char in url";
     state->error_pos = (const char*) p;
@@ -13636,7 +15679,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_43: {
+  s_n_llhttp__internal__n_error_52: {
     state->error = 0x6;
     state->reason = "Expected space after method";
     state->error_pos = (const char*) p;
@@ -13653,7 +15696,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_51: {
+  s_n_llhttp__internal__n_error_64: {
     state->error = 0x6;
     state->reason = "Invalid method encountered";
     state->error_pos = (const char*) p;
@@ -13662,7 +15705,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_44: {
+  s_n_llhttp__internal__n_error_55: {
     state->error = 0xd;
     state->reason = "Response overflow";
     state->error_pos = (const char*) p;
@@ -13674,7 +15717,7 @@ static llparse_state_t llhttp__internal__run(
   s_n_llhttp__internal__n_invoke_mul_add_status_code: {
     switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
       case 1:
-        goto s_n_llhttp__internal__n_error_44;
+        goto s_n_llhttp__internal__n_error_55;
       default:
         goto s_n_llhttp__internal__n_res_status_code;
     }
@@ -13691,11 +15734,11 @@ static llparse_state_t llhttp__internal__run(
     if (err != 0) {
       state->error = err;
       state->error_pos = (const char*) (p + 1);
-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_field_start;
+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
       return s_error;
     }
     p++;
-    goto s_n_llhttp__internal__n_header_field_start;
+    goto s_n_llhttp__internal__n_invoke_llhttp__on_status_complete;
     /* UNREACHABLE */;
     abort();
   }
@@ -13717,7 +15760,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_45: {
+  s_n_llhttp__internal__n_error_56: {
     state->error = 0xd;
     state->reason = "Invalid response status";
     state->error_pos = (const char*) p;
@@ -13734,7 +15777,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_46: {
+  s_n_llhttp__internal__n_error_57: {
     state->error = 0x9;
     state->reason = "Expected space after version";
     state->error_pos = (const char*) p;
@@ -13743,15 +15786,107 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_invoke_store_http_minor_1: {
-    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
-      default:
+  s_n_llhttp__internal__n_error_54: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_3: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 9:
         goto s_n_llhttp__internal__n_res_http_end;
+      default:
+        goto s_n_llhttp__internal__n_error_54;
     }
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_47: {
+  s_n_llhttp__internal__n_error_58: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_4: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_res_http_end;
+      case 1:
+        goto s_n_llhttp__internal__n_res_http_end;
+      default:
+        goto s_n_llhttp__internal__n_error_58;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_59: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_minor_5: {
+    switch (llhttp__internal__c_load_http_minor(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_res_http_end;
+      default:
+        goto s_n_llhttp__internal__n_error_59;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_53: {
+    state->error = 0x9;
+    state->reason = "Invalid HTTP version";
+    state->error_pos = (const char*) p;
+    state->_current = (void*) (intptr_t) s_error;
+    return s_error;
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_load_http_major_1: {
+    switch (llhttp__internal__c_load_http_major(state, p, endp)) {
+      case 0:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_3;
+      case 1:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_4;
+      case 2:
+        goto s_n_llhttp__internal__n_invoke_load_http_minor_5;
+      default:
+        goto s_n_llhttp__internal__n_error_53;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_test_lenient_flags_10: {
+    switch (llhttp__internal__c_test_lenient_flags_9(state, p, endp)) {
+      case 1:
+        goto s_n_llhttp__internal__n_res_http_end;
+      default:
+        goto s_n_llhttp__internal__n_invoke_load_http_major_1;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_invoke_store_http_minor_1: {
+    switch (llhttp__internal__c_store_http_minor(state, p, endp, match)) {
+      default:
+        goto s_n_llhttp__internal__n_invoke_test_lenient_flags_10;
+    }
+    /* UNREACHABLE */;
+    abort();
+  }
+  s_n_llhttp__internal__n_error_60: {
     state->error = 0x9;
     state->reason = "Invalid minor version";
     state->error_pos = (const char*) p;
@@ -13760,7 +15895,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_48: {
+  s_n_llhttp__internal__n_error_61: {
     state->error = 0x9;
     state->reason = "Expected dot";
     state->error_pos = (const char*) p;
@@ -13777,7 +15912,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_49: {
+  s_n_llhttp__internal__n_error_62: {
     state->error = 0x9;
     state->reason = "Invalid major version";
     state->error_pos = (const char*) p;
@@ -13786,7 +15921,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_52: {
+  s_n_llhttp__internal__n_error_65: {
     state->error = 0x8;
     state->reason = "Expected HTTP/";
     state->error_pos = (const char*) p;
@@ -13811,7 +15946,7 @@ static llparse_state_t llhttp__internal__run(
     /* UNREACHABLE */;
     abort();
   }
-  s_n_llhttp__internal__n_error_50: {
+  s_n_llhttp__internal__n_error_63: {
     state->error = 0x8;
     state->reason = "Invalid word encountered";
     state->error_pos = (const char*) p;

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2318,6 +2318,18 @@ malconfigured clients, if more than 8KB of HTTP header data is received then
 HTTP parsing will abort without a request or response object being created, and
 an `Error` with this code will be emitted.
 
+<a id="HPE_CHUNK_EXTENSIONS_OVERFLOW"></a>
+
+### `HPE_CHUNK_EXTENSIONS_OVERFLOW`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Too much data was received for a chunk extensions. In order to protect against
+malicious or malconfigured clients, if more than 16 KiB of data is received
+then an `Error` with this code will be emitted.
+
 <a id="HPE_UNEXPECTED_CONTENT_LENGTH"></a>
 ### `HPE_UNEXPECTED_CONTENT_LENGTH`
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -636,6 +636,10 @@ const requestHeaderFieldsTooLargeResponse = Buffer.from(
   `HTTP/1.1 431 ${STATUS_CODES[431]}${CRLF}` +
   `Connection: close${CRLF}${CRLF}`, 'ascii'
 );
+const requestChunkExtensionsTooLargeResponse = Buffer.from(
+  `HTTP/1.1 413 ${STATUS_CODES[413]}${CRLF}` +
+  `Connection: close${CRLF}${CRLF}`, 'ascii',
+);
 function socketOnError(e) {
   // Ignore further errors
   this.removeListener('error', socketOnError);
@@ -648,6 +652,9 @@ function socketOnError(e) {
       switch (e.code) {
         case 'HPE_HEADER_OVERFLOW':
           response = requestHeaderFieldsTooLargeResponse;
+          break;
+        case 'HPE_CHUNK_EXTENSIONS_OVERFLOW':
+          response = requestChunkExtensionsTooLargeResponse;
           break;
         case 'ERR_HTTP_REQUEST_TIMEOUT':
           response = requestTimeoutResponse;

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -78,6 +78,8 @@ const uint32_t kOnExecute = 5;
 const uint32_t kOnTimeout = 6;
 // Any more fields than this will be flushed into JS
 const size_t kMaxHeaderFieldsCount = 32;
+// Maximum size of chunk extensions
+const size_t kMaxChunkExtensionsSize = 16384;
 
 inline bool IsOWS(char c) {
   return c == ' ' || c == '\t';
@@ -202,6 +204,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   int on_message_begin() {
     num_fields_ = num_values_ = 0;
+    chunk_extensions_nread_ = 0;
     url_.Reset();
     status_message_.Reset();
     header_parsing_start_time_ = uv_hrtime();
@@ -451,9 +454,22 @@ class Parser : public AsyncWrap, public StreamListener {
     return 0;
   }
 
-  // Reset nread for the next chunk
+  int on_chunk_extension(const char* at, size_t length) {
+    chunk_extensions_nread_ += length;
+
+    if (chunk_extensions_nread_ > kMaxChunkExtensionsSize) {
+      llhttp_set_error_reason(&parser_,
+        "HPE_CHUNK_EXTENSIONS_OVERFLOW:Chunk extensions overflow");
+      return HPE_USER;
+    }
+
+    return 0;
+  }
+
+  // Reset nread for the next chunk and also reset the extensions counter
   int on_chunk_header() {
     header_nread_ = 0;
+    chunk_extensions_nread_ = 0;
     return 0;
   }
 
@@ -904,6 +920,7 @@ class Parser : public AsyncWrap, public StreamListener {
   unsigned int execute_depth_ = 0;
   bool pending_pause_ = false;
   uint64_t header_nread_ = 0;
+  uint64_t chunk_extensions_nread_ = 0;
   uint64_t max_http_header_size_;
   uint64_t headers_timeout_;
   uint64_t header_parsing_start_time_ = 0;
@@ -938,10 +955,19 @@ const llhttp_settings_t Parser::settings = {
   Proxy<DataCall, &Parser::on_header_field>::Raw,
   Proxy<DataCall, &Parser::on_header_value>::Raw,
   Proxy<Call, &Parser::on_headers_complete>::Raw,
+  Proxy<DataCall, &Parser::on_chunk_extension>::Raw,
   Proxy<DataCall, &Parser::on_body>::Raw,
   Proxy<Call, &Parser::on_message_complete>::Raw,
   Proxy<Call, &Parser::on_chunk_header>::Raw,
   Proxy<Call, &Parser::on_chunk_complete>::Raw,
+  // on_url_complete
+  nullptr,
+  // on_status_complete
+  nullptr,
+  // on_header_field_complete
+  nullptr,
+  // on_header_value_complete
+  nullptr,
 };
 
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -860,7 +860,11 @@ class Parser : public AsyncWrap, public StreamListener {
   void Init(llhttp_type_t type, uint64_t max_http_header_size,
             bool lenient, uint64_t headers_timeout) {
     llhttp_init(&parser_, type, &settings);
-    llhttp_set_lenient(&parser_, lenient);
+    if (lenient) {
+      llhttp_set_lenient_headers(&parser_, 1);
+      llhttp_set_lenient_chunked_length(&parser_, 1);
+      llhttp_set_lenient_keep_alive(&parser_, 1);
+    }
     header_nread_ = 0;
     url_.Reset();
     status_message_.Reset();

--- a/test/parallel/test-http-chunk-extensions-limit.js
+++ b/test/parallel/test-http-chunk-extensions-limit.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const net = require('net');
+const assert = require('assert');
+
+// Verify that chunk extensions are limited in size when sent all together.
+{
+  const server = http.createServer((req, res) => {
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('bye');
+    });
+
+    req.resume();
+  });
+
+  server.listen(0, () => {
+    const sock = net.connect(server.address().port);
+    let data = '';
+
+    sock.on('data', (chunk) => data += chunk.toString('utf-8'));
+
+    sock.on('end', common.mustCall(function() {
+      assert.strictEqual(data, 'HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n');
+      server.close();
+    }));
+
+    sock.end('' +
+      'GET / HTTP/1.1\r\n' +
+      'Host: localhost:8080\r\n' +
+      'Transfer-Encoding: chunked\r\n\r\n' +
+      '2;' + 'A'.repeat(20000) + '=bar\r\nAA\r\n' +
+      '0\r\n\r\n'
+    );
+  });
+}
+
+// Verify that chunk extensions are limited in size when sent in intervals.
+{
+  const server = http.createServer((req, res) => {
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('bye');
+    });
+
+    req.resume();
+  });
+
+  server.listen(0, () => {
+    const sock = net.connect(server.address().port);
+    let remaining = 20000;
+    let data = '';
+
+    const interval = setInterval(
+      () => {
+        if (remaining > 0) {
+          sock.write('A'.repeat(1000));
+        } else {
+          sock.write('=bar\r\nAA\r\n0\r\n\r\n');
+          clearInterval(interval);
+        }
+
+        remaining -= 1000;
+      },
+      common.platformTimeout(20),
+    ).unref();
+
+    sock.on('data', (chunk) => data += chunk.toString('utf-8'));
+
+    sock.on('end', common.mustCall(function() {
+      assert.strictEqual(data, 'HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n');
+      server.close();
+    }));
+
+    sock.write('' +
+    'GET / HTTP/1.1\r\n' +
+    'Host: localhost:8080\r\n' +
+    'Transfer-Encoding: chunked\r\n\r\n' +
+    '2;'
+    );
+  });
+}
+
+// Verify the chunk extensions is correctly reset after a chunk
+{
+  const server = http.createServer((req, res) => {
+    req.on('end', () => {
+      res.writeHead(200, { 'content-type': 'text/plain', 'connection': 'close', 'date': 'now' });
+      res.end('bye');
+    });
+
+    req.resume();
+  });
+
+  server.listen(0, () => {
+    const sock = net.connect(server.address().port);
+    let data = '';
+
+    sock.on('data', (chunk) => data += chunk.toString('utf-8'));
+
+    sock.on('end', common.mustCall(function() {
+      assert.strictEqual(
+        data,
+        'HTTP/1.1 200 OK\r\n' +
+        'content-type: text/plain\r\n' +
+        'connection: close\r\n' +
+        'date: now\r\n' +
+        'Transfer-Encoding: chunked\r\n' +
+        '\r\n' +
+        '3\r\n' +
+        'bye\r\n' +
+        '0\r\n' +
+        '\r\n',
+      );
+
+      server.close();
+    }));
+
+    sock.end('' +
+      'GET / HTTP/1.1\r\n' +
+      'Host: localhost:8080\r\n' +
+      'Transfer-Encoding: chunked\r\n\r\n' +
+      '2;' + 'A'.repeat(10000) + '=bar\r\nAA\r\n' +
+      '2;' + 'A'.repeat(10000) + '=bar\r\nAA\r\n' +
+      '2;' + 'A'.repeat(10000) + '=bar\r\nAA\r\n' +
+      '0\r\n\r\n'
+    );
+  });
+}


### PR DESCRIPTION
Original fix for v18:
https://github.com/nodejs/node/commit/03a5c34a829742f1c47b68f831b2940af44addf6
   
On top of the v18 patch, we needed to initialize the rest of callbacks in order to avoid warnings like
```
    ../src/node_http_parser.cc:967:1: warning: missing initializer for member
      'llhttp_settings_s::on_header_value_complete' [-Wmissing-field-initializers]
```

Replace llhttp_set_lenient with llhttp_set_lenient_*variants
    
This change is related to https://github.com/nodejs/llhttp/commit/015e155358f03c49b0f16193bf146bafb08f3af9 that replaced a single llhttp_set_lenient with more granular calls.
However, we only have lenient bool, so set it all or none.

